### PR TITLE
Add SQLITE_TMPDIR=/tmp to make sqlite use a writable temp directory

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -65,3 +65,6 @@ if [ $needs_update = true ]; then
     update-mime-database $XDG_DATA_HOME/mime
   fi
 fi
+
+# Point sqlite3 to a writable directory for temp files
+export SQLITE_TMPDIR=/tmp


### PR DESCRIPTION
libsqlite3 will search through a number of locations looking for a directory that exists for it's temporary files. However, it doesn't check that it can create files in this directory. When run inside a snap, the first one it matches is /var/tmp/ which exists, but is not writable by the snap app. 

Setting SQLITE_TMPDIR will cause it to be found before /var/tmp/. The snap launcher mounts /tmp inside the snap's confinement as a writable temporary directory, so this should always work regardless of where the snap is installed.
