### PR TITLE
Add back the original parts as well so older versions of snapcraft-parser works.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,6 +34,86 @@ confinement: strict
 parts:
   desktop:
     plugin: nil
+  gtk2:
+    source: .
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk2"]
+    build-packages:
+      - libgtk2.0-dev
+    stage-packages:
+      - libxkbcommon0  # XKB_CONFIG_ROOT
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - shared-mime-info
+      - libgtk2.0-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk2.0-bin
+      - unity-gtk2-module
+  gtk3:
+    source: .
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - libgtk-3-dev
+    stage-packages:
+      - libxkbcommon0  # XKB_CONFIG_ROOT
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - shared-mime-info
+      - libgtk-3-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk-3-bin
+      - unity-gtk3-module
+  qt4:
+    source: .
+    source-subdir: qt
+    plugin: make
+    make-parameters: ["FLAVOR=qt4"]
+    build-packages:
+      - libqt4-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - shared-mime-info
+      - libqtgui4
+      - libgdk-pixbuf2.0-0
+      - libqt4-svg # for loading icon themes which are svg
+      - appmenu-qt
+  qt5:
+    source: .
+    source-subdir: qt
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - appmenu-qt5
+  glib-only:
+    source: .
+    source-subdir: glib-only
+    plugin: make
+    build-packages:
+      - libglib2.0-dev
+    stage-packages:
+      - libglib2.0-bin
   desktop/gtk2:
     source: .
     source-subdir: gtk


### PR DESCRIPTION
These are still needed until the non-namespaced version of snapcraft-parser is released.