### PR TITLE
common/desktop-exports: don't dereference target symlink on upgrades

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -53,7 +53,7 @@ export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
   ln -sf $SNAP/usr/share/{fontconfig,fonts,fonts-*,themes} $XDG_DATA_HOME
-  ln -sf $SNAP/usr/share/themes $SNAP_USER_DATA/.themes
+  ln -sfn $SNAP/usr/share/themes $SNAP_USER_DATA/.themes
 fi
 
 # Build mime.cache


### PR DESCRIPTION
On install, $SNAP_USER_DATA/.themes is created and points to
$SNAP/usr/share/themes. On upgrade $SNAP_USER_DATA is copied from the previous
dir (eg, 'x1') to the new version (eg, 'x2') such that $SNAP_USER_DATA/.themes
points to the previous version's $SNAP/usr/share/themes. There is logic to
account for this in common/desktop-exports and it tries to:

  ln -sf $SNAP/usr/share/themes $SNAP_USER_DATA/.themes

Because $SNAP_USER_DATA/.themes is a valid symlink, it is dereferenced and
tries to create $SNAP/usr/share/themes/themes, which is of course a readonly
directly and fails with:

  ln: failed to create symbolic link '.../x2/.themes/themes': Read-only file
  system

The script should instead use '-n' so that $SNAP_USER_DATA/.themes is updated
as intended.