### PR TITLE
Install all available locales and ensure that apps can locate them.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -71,3 +71,6 @@ if [ $needs_update = true ]; then
     update-mime-database $XDG_DATA_HOME/mime
   fi
 fi
+
+# Ensure the app finds locale definitions (requires locales-all to be installed)
+export LOCPATH=$SNAP/usr/lib/locale

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
       - libglib2.0-bin
       - libgtk2.0-bin
       - unity-gtk2-module
+      - locales-all
   gtk3:
     source: .
     source-subdir: gtk
@@ -70,6 +71,7 @@ parts:
       - libglib2.0-bin
       - libgtk-3-bin
       - unity-gtk3-module
+      - locales-all
   qt4:
     source: .
     source-subdir: qt
@@ -88,6 +90,7 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
+      - locales-all
   qt5:
     source: .
     source-subdir: qt
@@ -106,6 +109,7 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
+      - locales-all
   glib-only:
     source: .
     source-subdir: glib-only
@@ -132,6 +136,7 @@ parts:
       - libglib2.0-bin
       - libgtk2.0-bin
       - unity-gtk2-module
+      - locales-all
   desktop/gtk3:
     source: .
     source-subdir: gtk
@@ -150,6 +155,7 @@ parts:
       - libglib2.0-bin
       - libgtk-3-bin
       - unity-gtk3-module
+      - locales-all
   desktop/qt4:
     source: .
     source-subdir: qt
@@ -168,6 +174,7 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
+      - locales-all
   desktop/qt5:
     source: .
     source-subdir: qt
@@ -186,6 +193,7 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
+      - locales-all
   desktop/glib-only:
     source: .
     source-subdir: glib-only
@@ -212,6 +220,7 @@ parts:
       - libglib2.0-bin
       - libgtk2.0-bin
       - unity-gtk2-module
+      - locales-all
   desktop-gtk3:
     source: .
     source-subdir: gtk
@@ -230,6 +239,7 @@ parts:
       - libglib2.0-bin
       - libgtk-3-bin
       - unity-gtk3-module
+      - locales-all
   desktop-qt4:
     source: .
     source-subdir: qt
@@ -248,6 +258,7 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
+      - locales-all
   desktop-qt5:
     source: .
     source-subdir: qt
@@ -266,6 +277,7 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
+      - locales-all
   desktop-glib-only:
     source: .
     source-subdir: glib-only


### PR DESCRIPTION
This is a workaround for the lack of locale definitions in the core image
(https://launchpad.net/bugs/1576282).