### PR TITLE
Export GI_TYPELIB_PATH in all cases

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -53,6 +53,9 @@ mkdir -p $XDG_DATA_HOME
 export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
 mkdir -p $XDG_CACHE_HOME
 
+# GI repository
+export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+
 # Font Config and themes
 export FONTCONFIG_PATH=$SNAP/etc/fonts/conf.d
 export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf

--- a/glib-only/launcher-specific
+++ b/glib-only/launcher-specific
@@ -11,9 +11,6 @@ if [ $needs_update = true ]; then
   $SNAP/usr/lib/$ARCH/glib-2.0/gio-querymodules $GIO_MODULE_DIR
 fi
 
-# GI repository
-export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
-
 # Keep an array of data dirs, for looping through them
 IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -27,9 +27,6 @@ if [ $needs_update = true ]; then
   fi
 fi
 
-# GI repository
-export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
-
 if [ "$USE_gtk3" = true ]; then
   export GTK_PATH=$SNAP/usr/lib/$ARCH/gtk-3.0
 else


### PR DESCRIPTION
Move the export of GI_TYPELIB_PATH from glib and gtk to the common exports file. I found that I needed this in my Qt application, which calls a python tool that uses gi. Instead of slowly adding this to every launcher-specific file, it seems like a good time to set it in all scenarios.