### PR TITLE
Export $SNAP_LAUNCHER_ARCH

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -20,6 +20,8 @@ else
   ARCH="$SNAP_ARCH-linux-gnu"
 fi
 
+export SNAP_LAUNCHER_ARCH=$ARCH
+
 # XKB config
 export XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -20,7 +20,7 @@ else
   ARCH="$SNAP_ARCH-linux-gnu"
 fi
 
-export SNAP_LAUNCHER_ARCH=$ARCH
+export SNAP_LAUNCHER_ARCH_TRIPLET=$ARCH
 
 # XKB config
 export XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb


### PR DESCRIPTION
Exports the launcher ARCH so that wrapper scripts launched by the launcher
can reuse this value without recomputing it again