### PR TITLE
Update the gtk launcher to be compatible with the new gnome runtime.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -22,15 +22,34 @@ fi
 
 export SNAP_LAUNCHER_ARCH_TRIPLET=$ARCH
 
+if [ -d $SNAP/gnome-runtime ]; then
+  if [ ! -d $SNAP/gnome-runtime/usr ]; then
+    echo "You need to connect the snap to the gnome-runtime interface."
+    echo ""
+    echo "You can do this with those commands:"
+    echo "snap install gnome318-udt"
+    echo "snap connect $SNAP_NAME:gnome318-runtime gnome318-udt:gnome318-runtime"
+    echo ""
+    echo "(the '318' number defines the runtime version and might change)"
+    exit 1
+  else
+    RUNTIMEDIR=$SNAP/gnome-runtime
+    export LD_LIBRARY_PATH=$RUNTIMEDIR/usr/lib/$ARCH:$LD_LIBRARY_PATH
+    export PATH=$RUNTIMEDIR/usr/bin:$PATH
+  fi
+else
+  RUNTIMEDIR=$SNAP
+fi
+
 # XKB config
-export XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb
+export XKB_CONFIG_ROOT=$RUNTIMEDIR/usr/share/X11/xkb
 
 # Mesa Libs for OpenGL support
-export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$RUNTIMEDIR/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$RUNTIMEDIR/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
 
 # Tell libGL where to find the drivers
-export LIBGL_DRIVERS_PATH=$SNAP/usr/lib/$ARCH/dri
+export LIBGL_DRIVERS_PATH=$RUNTIMEDIR/usr/lib/$ARCH/dri
 export LD_LIBRARY_PATH=$LIBGL_DRIVERS_PATH:$LD_LIBRARY_PATH
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
@@ -40,19 +59,19 @@ export LD_LIBRARY_PATH=$LIBGL_DRIVERS_PATH:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/var/lib/snapd/lib/gl:$LD_LIBRARY_PATH
 
 # Tell where to find the client libraries for Mir
-export MIR_CLIENT_PLATFORM_PATH=$SNAP/usr/lib/$ARCH/mir/client-platform
+export MIR_CLIENT_PLATFORM_PATH=$RUNTIMEDIR/usr/lib/$ARCH/mir/client-platform
 
 # Pulseaudio export
-##export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/pulseaudio:$LD_LIBRARY_PATH
+##export LD_LIBRARY_PATH=$RUNTIMEDIR/usr/lib/$ARCH/pulseaudio:$LD_LIBRARY_PATH
 
 # Tell GStreamer where to find its system plugins
-export GST_PLUGIN_SYSTEM_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
+export GST_PLUGIN_SYSTEM_PATH=$RUNTIMEDIR/usr/lib/$ARCH/gstreamer-1.0
 
 # XDG Config
-export XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS
+export XDG_CONFIG_DIRS=$RUNTIMEDIR/etc/xdg:$RUNTIMEDIR/usr/xdg:$XDG_CONFIG_DIRS
 
 # Define snaps' own data dir
-export XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
+export XDG_DATA_DIRS=$SNAP_USER_DATA:$RUNTIMEDIR/usr/share:$XDG_DATA_DIRS
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
@@ -64,15 +83,15 @@ export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
 mkdir -p $XDG_CACHE_HOME
 
 # GI repository
-export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+export GI_TYPELIB_PATH=$RUNTIMEDIR/usr/lib/girepository-1.0:$RUNTIMEDIR/usr/lib/$ARCH/girepository-1.0
 
 # Font Config and themes
-export FONTCONFIG_PATH=$SNAP/etc/fonts/conf.d
-export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
+export FONTCONFIG_PATH=$RUNTIMEDIR/etc/fonts/conf.d
+export FONTCONFIG_FILE=$RUNTIMEDIR/etc/fonts/fonts.conf
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
-  ln -sf $SNAP/usr/share/{fontconfig,fonts,fonts-*,themes} $XDG_DATA_HOME
-  ln -sfn $SNAP/usr/share/themes $SNAP_USER_DATA/.themes
+  ln -sf $RUNTIMEDIR/usr/share/{fontconfig,fonts,fonts-*,themes} $XDG_DATA_HOME
+  ln -sfn $RUNTIMEDIR/usr/share/themes $SNAP_USER_DATA/.themes
 fi
 
 # Build mime.cache
@@ -80,13 +99,13 @@ fi
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/mime
   if [ `which update-mime-database` ]; then
-    cp --preserve=timestamps -dR $SNAP/usr/share/mime $XDG_DATA_HOME
+    cp --preserve=timestamps -dR $RUNTIMEDIR/usr/share/mime $XDG_DATA_HOME
     update-mime-database $XDG_DATA_HOME/mime
   fi
 fi
 
 # Ensure the app finds locale definitions (requires locales-all to be installed)
-export LOCPATH=$SNAP/usr/lib/locale
+export LOCPATH=$RUNTIMEDIR/usr/lib/locale
 
 # Gio modules and cache (including gsettings module)
 export GIO_MODULE_DIR=$XDG_CACHE_HOME/gio-modules
@@ -99,7 +118,7 @@ function compile_giomodules {
   fi
 }
 if [ $needs_update = true ]; then
-  compile_giomodules $SNAP/usr/lib/$ARCH
+  compile_giomodules $RUNTIMEDIR/usr/lib/$ARCH
 fi
 
 # Keep an array of data dirs, for looping through them
@@ -121,7 +140,7 @@ function compile_schemas {
   fi
 }
 if [ $needs_update = true ]; then
-  compile_schemas $SNAP/usr/lib/$ARCH/glib-2.0/glib-compile-schemas
+  compile_schemas $RUNTIMEDIR/usr/lib/$ARCH/glib-2.0/glib-compile-schemas
 fi
 
 # Enable gsettings user changes

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -7,19 +7,19 @@
 
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
-export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
+export GDK_PIXBUF_MODULEDIR=$RUNTIMEDIR/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
 
 if [ $needs_update = true ]; then
   rm -f $GDK_PIXBUF_MODULE_FILE
-  if [ -f $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
-    $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+  if [ -f $RUNTIMEDIR/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+    $RUNTIMEDIR/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
   fi
 fi
 
 if [ "$USE_gtk3" = true ]; then
-  export GTK_PATH=$SNAP/usr/lib/$ARCH/gtk-3.0
+  export GTK_PATH=$RUNTIMEDIR/usr/lib/$ARCH/gtk-3.0
 else
-  export GTK_PATH=$SNAP/usr/lib/$ARCH/gtk-2.0
+  export GTK_PATH=$RUNTIMEDIR/usr/lib/$ARCH/gtk-2.0
 fi
 
 # ibus and fcitx integration
@@ -31,11 +31,11 @@ if [ $needs_update = true ]; then
   rm -rf $GTK_IM_MODULE_DIR
   mkdir -p $GTK_IM_MODULE_DIR
   if [ "$USE_gtk3" = true ]; then
-    ln -s $SNAP/usr/lib/$ARCH/gtk-3.0/3.0.0/immodules/*.so $GTK_IM_MODULE_DIR
-    $SNAP/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0 > $GTK_IM_MODULE_FILE
+    ln -s $RUNTIMEDIR/usr/lib/$ARCH/gtk-3.0/3.0.0/immodules/*.so $GTK_IM_MODULE_DIR
+    $RUNTIMEDIR/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0 > $GTK_IM_MODULE_FILE
   else
-    ln -s $SNAP/usr/lib/$ARCH/gtk-2.0/2.10.0/immodules/*.so $GTK_IM_MODULE_DIR
-    $SNAP/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0 > $GTK_IM_MODULE_FILE
+    ln -s $RUNTIMEDIR/usr/lib/$ARCH/gtk-2.0/2.10.0/immodules/*.so $GTK_IM_MODULE_DIR
+    $RUNTIMEDIR/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0 > $GTK_IM_MODULE_FILE
   fi
 fi
 
@@ -50,10 +50,10 @@ if [ $needs_update = true ]; then
         if [ ! -d "$theme_dir" ]; then
           mkdir -p "$theme_dir"
           ln -s $i/* "$theme_dir"
-          if [ -f $SNAP/usr/sbin/update-icon-caches ]; then
-            $SNAP/usr/sbin/update-icon-caches "$theme_dir"
-          elif [ -f $SNAP/usr/sbin/update-icon-cache.gtk2 ]; then
-            $SNAP/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
+          if [ -f $RUNTIMEDIR/usr/sbin/update-icon-caches ]; then
+            $RUNTIMEDIR/usr/sbin/update-icon-caches "$theme_dir"
+          elif [ -f $RUNTIMEDIR/usr/sbin/update-icon-cache.gtk2 ]; then
+            $RUNTIMEDIR/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
           fi
         fi
       fi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,6 +14,8 @@ description: |
        - gtk2, gtk3, qt4 and qt5 corresponds to their respective toolkit
          main dependencies and default choices.
        - ubuntu-app-platform corresponds to the shared platform snap use.
+       - gnome is similar to gtk3 without the depends, it's meant to
+         be used with the gnome runtime which already includes those.
        - glib-only enables to compile mime types and gsettings infos. If you
          added your own graphical drivers, it will link them as well.
     2. prepend your command with "desktop-launch", like:
@@ -39,11 +41,28 @@ description: |
                target: ubuntu-app-platform
          and then make your apps use it:
            plugs: [platform]
+       - similarly for the gnome runtime
+          plugs:
+              gnome-runtime:
+                content: gnome318-runtime
+                default-provider: gnome318-udt:gnome318-runtime
+                interface: content
+                target: gnome-runtime
+         and then make your apps use it:
+           plugs: [gnome-runtime]
+
 confinement: strict
 
 parts:
   desktop:
     plugin: nil
+  gnome:
+    source: .
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - libgtk-3-dev
   gtk2:
     source: .
     source-subdir: gtk


### PR DESCRIPTION
Define a new 'gnome' helper which is similar to the gtk3 but doesn't
include the depends since those are part of the shared content.