### PR TITLE
[WIP] Add ubuntu-app-themes to paths

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -52,7 +52,10 @@ export GST_PLUGIN_SYSTEM_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
 export XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS
 
 # Define snaps' own data dir
-export XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
+export XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$SNAP/ubuntu-app-themes/usr/share:$XDG_DATA_DIRS
+
+# Add the GTK3 path of ubuntu-app-themes dirs (in case they're being used)
+export XDG_DATA_DIRS=$XDG_DATA_DIRS:$SNAP/ubuntu-app-themes/usr/share
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -28,8 +28,8 @@ export QTCOMPOSE=$SNAP/usr/share/X11/locale
 
 # Qt Libs, Modules and helpers
 if [ "$USE_qt5" = true ]; then
-  export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$LD_LIBRARY_PATH
-  export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins
+  export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$SNAP/ubuntu-app-themes/usr/lib/$ARCH:$LD_LIBRARY_PATH
+  export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins:$SNAP/ubuntu-app-themes/usr/lib/$ARCH/qt5/plugins
   export QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$SNAP/usr/lib/$ARCH/qt5/bin:$PATH
 elif [ "$USE_qt5appplatform" = true ]; then
@@ -51,8 +51,8 @@ elif [ "$USE_qt5appplatform" = true ]; then
   XDG_DATA_DIRS=$XDG_DATA_DIRS:$SNAP/ubuntu-app-platform/usr/share
   export MIR_CLIENT_PLATFORM_PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/mir/client-platform
 
-  export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$SNAP/ubuntu-app-platform/usr/lib/$ARCH:$LD_LIBRARY_PATH
-  export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins:$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/plugins
+  export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$SNAP/ubuntu-app-platform/usr/lib/$ARCH:$SNAP/ubuntu-app-themes/usr/lib/$ARCH:$LD_LIBRARY_PATH
+  export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins:$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/plugins:$SNAP/ubuntu-app-themes/usr/lib/$ARCH/qt5/plugins
   export QML2_IMPORT_PATH=$SNAP/usr/lib/$ARCH/qt5/qml:$SNAP/lib/$ARCH:$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/qml:$SNAP/ubuntu-app-platform/lib/$ARCH:$QML2_IMPORT_PATH
   PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/bin:$PATH
 else


### PR DESCRIPTION
This way we enable snaps that plug into ubuntu-app-themes to have extra GTK/Qt5 themes available

If the plug is not connected the extra paths will just be ignored

Tested together with 
https://code.launchpad.net/~aacid/+junk/ubuntu-app-themes
https://code.launchpad.net/~aacid/+junk/style-chooser-example-qt5
https://code.launchpad.net/~aacid/+junk/breeze-button-example-gtk