### PR TITLE
Runtime refactor

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -2,26 +2,6 @@
 # Launcher common exports for any desktop app #
 ###############################################
 
-needs_update=true
-
-. ~/.last_revision 2>/dev/null || true
-if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
-  needs_update=false
-fi
-[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > ~/.last_revision
-
-if [ "$SNAP_ARCH" == "amd64" ]; then
-  ARCH="x86_64-linux-gnu"
-elif [ "$SNAP_ARCH" == "armhf" ]; then
-  ARCH="arm-linux-gnueabihf"
-elif [ "$SNAP_ARCH" == "arm64" ]; then
-  ARCH="aarch64-linux-gnu"
-else
-  ARCH="$SNAP_ARCH-linux-gnu"
-fi
-
-export SNAP_LAUNCHER_ARCH_TRIPLET=$ARCH
-
 # XKB config
 export XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -2,15 +2,23 @@
 # Launcher common exports for any desktop app #
 ###############################################
 
+if [ -z "$RUNTIME" ]; then
+  RUNTIME=$SNAP
+else
+  # add general paths not added by snapcraft due to runtime snap
+  export LD_LIBRARY_PATH=$RUNTIME/usr/lib/$ARCH:$LD_LIBRARY_PATH
+  export PATH=$RUNTIME/usr/bin:$PATH
+fi
+
 # XKB config
-export XKB_CONFIG_ROOT=$SNAP/usr/share/X11/xkb
+export XKB_CONFIG_ROOT=$RUNTIME/usr/share/X11/xkb
 
 # Mesa Libs for OpenGL support
-export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$RUNTIME/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$RUNTIME/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
 
 # Tell libGL where to find the drivers
-export LIBGL_DRIVERS_PATH=$SNAP/usr/lib/$ARCH/dri
+export LIBGL_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
 export LD_LIBRARY_PATH=$LIBGL_DRIVERS_PATH:$LD_LIBRARY_PATH
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
@@ -20,19 +28,19 @@ export LD_LIBRARY_PATH=$LIBGL_DRIVERS_PATH:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/var/lib/snapd/lib/gl:$LD_LIBRARY_PATH
 
 # Tell where to find the client libraries for Mir
-export MIR_CLIENT_PLATFORM_PATH=$SNAP/usr/lib/$ARCH/mir/client-platform
+export MIR_CLIENT_PLATFORM_PATH=$RUNTIME/usr/lib/$ARCH/mir/client-platform
 
 # Pulseaudio export
-##export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/pulseaudio:$LD_LIBRARY_PATH
+##export LD_LIBRARY_PATH=$RUNTIME/usr/lib/$ARCH/pulseaudio:$LD_LIBRARY_PATH
 
 # Tell GStreamer where to find its system plugins
-export GST_PLUGIN_SYSTEM_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
+export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
 
 # XDG Config
-export XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS
+export XDG_CONFIG_DIRS=$RUNTIME/etc/xdg:$RUNTIME/usr/xdg:$XDG_CONFIG_DIRS
 
 # Define snaps' own data dir
-export XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
+export XDG_DATA_DIRS=$SNAP_USER_DATA:$RUNTIME/usr/share:$XDG_DATA_DIRS
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
@@ -44,15 +52,15 @@ export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
 mkdir -p $XDG_CACHE_HOME
 
 # GI repository
-export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+export GI_TYPELIB_PATH=$RUNTIME/usr/lib/girepository-1.0:$RUNTIME/usr/lib/$ARCH/girepository-1.0
 
 # Font Config and themes
-export FONTCONFIG_PATH=$SNAP/etc/fonts/conf.d
-export FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
+export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d
+export FONTCONFIG_FILE=$RUNTIME/etc/fonts/fonts.conf
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
-  ln -sf $SNAP/usr/share/{fontconfig,fonts,fonts-*,themes} $XDG_DATA_HOME
-  ln -sfn $SNAP/usr/share/themes $SNAP_USER_DATA/.themes
+  ln -sf $RUNTIME/usr/share/{fontconfig,fonts,fonts-*,themes} $XDG_DATA_HOME
+  ln -sfn $RUNTIME/usr/share/themes $SNAP_USER_DATA/.themes
 fi
 
 # Build mime.cache
@@ -60,13 +68,13 @@ fi
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/mime
   if [ `which update-mime-database` ]; then
-    cp --preserve=timestamps -dR $SNAP/usr/share/mime $XDG_DATA_HOME
+    cp --preserve=timestamps -dR $RUNTIME/usr/share/mime $XDG_DATA_HOME
     update-mime-database $XDG_DATA_HOME/mime
   fi
 fi
 
 # Ensure the app finds locale definitions (requires locales-all to be installed)
-export LOCPATH=$SNAP/usr/lib/locale
+export LOCPATH=$RUNTIME/usr/lib/locale
 
 # Gio modules and cache (including gsettings module)
 export GIO_MODULE_DIR=$XDG_CACHE_HOME/gio-modules
@@ -79,7 +87,7 @@ function compile_giomodules {
   fi
 }
 if [ $needs_update = true ]; then
-  compile_giomodules $SNAP/usr/lib/$ARCH
+  compile_giomodules $RUNTIME/usr/lib/$ARCH
 fi
 
 # Keep an array of data dirs, for looping through them
@@ -101,7 +109,7 @@ function compile_schemas {
   fi
 }
 if [ $needs_update = true ]; then
-  compile_schemas $SNAP/usr/lib/$ARCH/glib-2.0/glib-compile-schemas
+  compile_schemas $RUNTIME/usr/lib/$ARCH/glib-2.0/glib-compile-schemas
 fi
 
 # Enable gsettings user changes

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -2,14 +2,14 @@
 # Launcher common exports for any desktop app #
 ###############################################
 
-USE_RUNTIME=no
+WITH_RUNTIME=no
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
 else
   # add general paths not added by snapcraft due to runtime snap
   export LD_LIBRARY_PATH=$RUNTIME/usr/lib/$ARCH:$LD_LIBRARY_PATH
   export PATH=$RUNTIME/usr/bin:$PATH
-  USE_RUNTIME=yes
+  WITH_RUNTIME=yes
 fi
 
 # XKB config
@@ -40,11 +40,11 @@ export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
 
 # XDG Config
 export XDG_CONFIG_DIRS=$RUNTIME/etc/xdg:$RUNTIME/usr/xdg:$XDG_CONFIG_DIRS
-[ "$USE_RUNTIME" = yes ] && XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS # add local SNAP assets if a runtime is used
+[ "$WITH_RUNTIME" = yes ] && XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS # add local SNAP assets if a runtime is used
 
 # Define snaps' own data dir
 export XDG_DATA_DIRS=$SNAP_USER_DATA:$RUNTIME/usr/share:$XDG_DATA_DIRS
-[ "$USE_RUNTIME" = yes ] && XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS # add local SNAP assets if a runtime is used
+[ "$WITH_RUNTIME" = yes ] && XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS # add local SNAP assets if a runtime is used
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
@@ -57,7 +57,7 @@ mkdir -p $XDG_CACHE_HOME
 
 # GI repository
 export GI_TYPELIB_PATH=$RUNTIME/usr/lib/girepository-1.0:$RUNTIME/usr/lib/$ARCH/girepository-1.0
-[ "$USE_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0 # add local SNAP assets if a runtime is used
+[ "$WITH_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0 # add local SNAP assets if a runtime is used
 
 # Font Config and themes
 export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -2,12 +2,14 @@
 # Launcher common exports for any desktop app #
 ###############################################
 
+USE_RUNTIME=no
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
 else
   # add general paths not added by snapcraft due to runtime snap
   export LD_LIBRARY_PATH=$RUNTIME/usr/lib/$ARCH:$LD_LIBRARY_PATH
   export PATH=$RUNTIME/usr/bin:$PATH
+  USE_RUNTIME=yes
 fi
 
 # XKB config
@@ -38,9 +40,11 @@ export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
 
 # XDG Config
 export XDG_CONFIG_DIRS=$RUNTIME/etc/xdg:$RUNTIME/usr/xdg:$XDG_CONFIG_DIRS
+[ "$USE_RUNTIME" = yes ] && XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS
 
 # Define snaps' own data dir
 export XDG_DATA_DIRS=$SNAP_USER_DATA:$RUNTIME/usr/share:$XDG_DATA_DIRS
+[ "$USE_RUNTIME" = yes ] && XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
@@ -53,6 +57,7 @@ mkdir -p $XDG_CACHE_HOME
 
 # GI repository
 export GI_TYPELIB_PATH=$RUNTIME/usr/lib/girepository-1.0:$RUNTIME/usr/lib/$ARCH/girepository-1.0
+[ "$USE_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
 
 # Font Config and themes
 export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -40,11 +40,11 @@ export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
 
 # XDG Config
 export XDG_CONFIG_DIRS=$RUNTIME/etc/xdg:$RUNTIME/usr/xdg:$XDG_CONFIG_DIRS
-[ "$USE_RUNTIME" = yes ] && XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS
+[ "$USE_RUNTIME" = yes ] && XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS # add local SNAP assets if a runtime is used
 
 # Define snaps' own data dir
 export XDG_DATA_DIRS=$SNAP_USER_DATA:$RUNTIME/usr/share:$XDG_DATA_DIRS
-[ "$USE_RUNTIME" = yes ] && XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
+[ "$USE_RUNTIME" = yes ] && XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS # add local SNAP assets if a runtime is used
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
@@ -57,7 +57,7 @@ mkdir -p $XDG_CACHE_HOME
 
 # GI repository
 export GI_TYPELIB_PATH=$RUNTIME/usr/lib/girepository-1.0:$RUNTIME/usr/lib/$ARCH/girepository-1.0
-[ "$USE_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+[ "$USE_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0 # add local SNAP assets if a runtime is used
 
 # Font Config and themes
 export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d

--- a/common/init
+++ b/common/init
@@ -1,0 +1,24 @@
+#################
+# Launcher init #
+#################
+
+needs_update=true
+
+. ~/.last_revision 2>/dev/null || true
+if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
+  needs_update=false
+fi
+[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > ~/.last_revision
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+export SNAP_LAUNCHER_ARCH_TRIPLET=$ARCH
+

--- a/glib-only/Makefile
+++ b/glib-only/Makefile
@@ -11,6 +11,7 @@ clean:
 
 $(DEST_LAUNCHER):
 	@echo "#!/bin/bash" > $(DEST_LAUNCHER)
+	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 		

--- a/glib-only/init
+++ b/glib-only/init
@@ -1,0 +1,1 @@
+../common/init

--- a/gtk/Makefile
+++ b/gtk/Makefile
@@ -14,6 +14,7 @@ clean:
 
 $(DEST_LAUNCHER):
 	@echo "#!/bin/bash" > $(DEST_LAUNCHER)
+	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 	@echo "USE_$(FLAVOR)=true" >> $(FLAVOR_FILE)

--- a/gtk/Makefile
+++ b/gtk/Makefile
@@ -15,6 +15,7 @@ clean:
 $(DEST_LAUNCHER):
 	@echo "#!/bin/bash" > $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
+	@cat $(SRC_DIR)/runtime-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 	@echo "USE_$(FLAVOR)=true" >> $(FLAVOR_FILE)

--- a/gtk/init
+++ b/gtk/init
@@ -1,0 +1,1 @@
+../common/init

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -7,19 +7,19 @@
 
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
-export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
+export GDK_PIXBUF_MODULEDIR=$RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
 
 if [ $needs_update = true ]; then
   rm -f $GDK_PIXBUF_MODULE_FILE
-  if [ -f $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
-    $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+  if [ -f $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+    $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
   fi
 fi
 
 if [ "$USE_gtk3" = true ]; then
-  export GTK_PATH=$SNAP/usr/lib/$ARCH/gtk-3.0
+  export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-3.0
 else
-  export GTK_PATH=$SNAP/usr/lib/$ARCH/gtk-2.0
+  export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-2.0
 fi
 
 # ibus and fcitx integration
@@ -31,11 +31,11 @@ if [ $needs_update = true ]; then
   rm -rf $GTK_IM_MODULE_DIR
   mkdir -p $GTK_IM_MODULE_DIR
   if [ "$USE_gtk3" = true ]; then
-    ln -s $SNAP/usr/lib/$ARCH/gtk-3.0/3.0.0/immodules/*.so $GTK_IM_MODULE_DIR
-    $SNAP/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0 > $GTK_IM_MODULE_FILE
+    ln -s $RUNTIME/usr/lib/$ARCH/gtk-3.0/3.0.0/immodules/*.so $GTK_IM_MODULE_DIR
+    $RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0 > $GTK_IM_MODULE_FILE
   else
-    ln -s $SNAP/usr/lib/$ARCH/gtk-2.0/2.10.0/immodules/*.so $GTK_IM_MODULE_DIR
-    $SNAP/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0 > $GTK_IM_MODULE_FILE
+    ln -s $RUNTIME/usr/lib/$ARCH/gtk-2.0/2.10.0/immodules/*.so $GTK_IM_MODULE_DIR
+    $RUNTIME/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0 > $GTK_IM_MODULE_FILE
   fi
 fi
 
@@ -50,10 +50,10 @@ if [ $needs_update = true ]; then
         if [ ! -d "$theme_dir" ]; then
           mkdir -p "$theme_dir"
           ln -s $i/* "$theme_dir"
-          if [ -f $SNAP/usr/sbin/update-icon-caches ]; then
-            $SNAP/usr/sbin/update-icon-caches "$theme_dir"
-          elif [ -f $SNAP/usr/sbin/update-icon-cache.gtk2 ]; then
-            $SNAP/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
+          if [ -f $RUNTIME/usr/sbin/update-icon-caches ]; then
+            $RUNTIME/usr/sbin/update-icon-caches "$theme_dir"
+          elif [ -f $RUNTIME/usr/sbin/update-icon-cache.gtk2 ]; then
+            $RUNTIME/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
           fi
         fi
       fi

--- a/gtk/runtime-exports
+++ b/gtk/runtime-exports
@@ -8,7 +8,7 @@ if [ -d $SNAP/gnome-runtime ]; then
     echo "You need to connect the snap to the gnome-runtime interface."
     echo ""
     echo "You can do this with those commands:"
-    echo "snap install gnome318-udt"
+    echo "snap install --edge gnome318-udt"
     echo "snap connect $SNAP_NAME:gnome318-runtime gnome318-udt:gnome318-runtime"
     echo ""
     echo "(the '318' number defines the runtime version and might change)"

--- a/gtk/runtime-exports
+++ b/gtk/runtime-exports
@@ -1,0 +1,18 @@
+###########################
+# GNOME runtime selection #
+###########################
+
+if [ -d $SNAP/gnome-runtime ]; then
+  RUNTIME=$SNAP/gnome-runtime
+  if [ ! -d $RUNTIME/usr ]; then
+    echo "You need to connect the snap to the gnome-runtime interface."
+    echo ""
+    echo "You can do this with those commands:"
+    echo "snap install gnome318-udt"
+    echo "snap connect $SNAP_NAME:gnome318-runtime gnome318-udt:gnome318-runtime"
+    echo ""
+    echo "(the '318' number defines the runtime version and might change)"
+    exit 1
+  fi
+fi
+

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -37,6 +37,7 @@ clean:
 desktop-launch:
 	@echo "#!/bin/bash" > $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
+	@cat $(SRC_DIR)/runtime-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 	@echo "$$QT5_APP_PLATFORM_CONF" > snappy-qt5-app-platform.conf

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -36,6 +36,7 @@ clean:
 
 desktop-launch:
 	@echo "#!/bin/bash" > $(DEST_LAUNCHER)
+	@cat $(SRC_DIR)/init >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/desktop-exports >> $(DEST_LAUNCHER)
 	@cat $(SRC_DIR)/launcher-specific >> $(DEST_LAUNCHER)
 	@echo "$$QT5_APP_PLATFORM_CONF" > snappy-qt5-app-platform.conf

--- a/qt/init
+++ b/qt/init
@@ -1,0 +1,1 @@
+../common/init

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -23,7 +23,7 @@ export QTCOMPOSE=$SNAP/usr/share/X11/locale
 # Qt Libs, Modules and helpers
 if [ "$USE_qt5" = true ]; then
   export QT_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/qt5/plugins
-  export QML2_IMPORT_PATH=$RUNTIME/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
+  export QML2_IMPORT_PATH=$RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
   if [ "$XDG_SESSION_TYPE" = "x11" ] ; then
     export QT_QPA_PLATFORM=xcb

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -24,7 +24,7 @@ export QTCOMPOSE=$SNAP/usr/share/X11/locale
 if [ "$USE_qt5" = true ]; then
   export QT_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/qt5/plugins
   export QML2_IMPORT_PATH=$RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
-  [ "$USE_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
+  [ "$WITH_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
   if [ "$XDG_SESSION_TYPE" = "x11" ] ; then
     export QT_QPA_PLATFORM=xcb

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -8,16 +8,10 @@
 # Qt Platform to Mir
 export QTCHOOSER_NO_GLOBAL_DIR=1
 if [ "$USE_qt5" = true ]; then
-  export QT_SELECT=snappy-qt5
-elif [ "$USE_qt5appplatform" = true ]; then
-  if [ ! -d $SNAP/ubuntu-app-platform/usr ] ; then
-    echo "You need to connect the ubuntu-app-platform package with your application "
-    echo "to reuse shared assets, please run:"
-    echo "snap install ubuntu-app-platform"
-    echo "snap connect $SNAP_NAME:platform ubuntu-app-platform:platform"
-    exit 1
+  # QT_SELECT not exported by ubuntu app platform runtime
+  if [ -z "$QT_SELECT" ]; then
+    export QT_SELECT=snappy-qt5
   fi
-  export QT_SELECT=snappy-qt5-app-platform
 else
   export QT_SELECT=snappy-qt4
 fi
@@ -28,33 +22,9 @@ export QTCOMPOSE=$SNAP/usr/share/X11/locale
 
 # Qt Libs, Modules and helpers
 if [ "$USE_qt5" = true ]; then
-  export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$LD_LIBRARY_PATH
-  export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins
-  export QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
-  PATH=$SNAP/usr/lib/$ARCH/qt5/bin:$PATH
-elif [ "$USE_qt5appplatform" = true ]; then
-  # GL and general libs coming from app platform
-  export LD_LIBRARY_PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/mesa:$LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/mesa-egl:$LD_LIBRARY_PATH
-  export LIBGL_DRIVERS_PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/dri
-  export LD_LIBRARY_PATH=$LIBGL_DRIVERS_PATH:$LD_LIBRARY_PATH
-  export XKB_CONFIG_ROOT=$SNAP/ubuntu-app-platform/usr/share/X11/xkb
-  export FONTCONFIG_PATH=$SNAP/ubuntu-app-platform/etc/fonts/conf.d
-  export FONTCONFIG_FILE=$SNAP/ubuntu-app-platform/etc/fonts/fonts.conf
-  if [ $needs_update = true ]; then
-    rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
-    ln -sf $SNAP/ubuntu-app-platform/usr/share/{fontconfig,fonts,fonts-*,themes} $XDG_DATA_HOME
-    ln -sfn $SNAP/ubuntu-app-platform/usr/share/themes $SNAP_USER_DATA/.themes
-  fi
-  export LOCPATH=$SNAP/ubuntu-app-platform/usr/lib/locale
-  export QTCOMPOSE=$SNAP/ubuntu-app-platform/usr/share/X11/locale
-  XDG_DATA_DIRS=$XDG_DATA_DIRS:$SNAP/ubuntu-app-platform/usr/share
-  export MIR_CLIENT_PLATFORM_PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/mir/client-platform
-
-  export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH:$SNAP/ubuntu-app-platform/usr/lib/$ARCH:$LD_LIBRARY_PATH
-  export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt5/plugins:$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/plugins
-  export QML2_IMPORT_PATH=$SNAP/usr/lib/$ARCH/qt5/qml:$SNAP/lib/$ARCH:$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/qml:$SNAP/ubuntu-app-platform/lib/$ARCH:$QML2_IMPORT_PATH
-  PATH=$SNAP/ubuntu-app-platform/usr/lib/$ARCH/qt5/bin:$PATH
+  export QT_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/qt5/plugins
+  export QML2_IMPORT_PATH=$RUNTIME/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
+  PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
 else
   export LD_LIBRARY_PATH=$SNAP/usr/lib/$ARCH/qt4:$LD_LIBRARY_PATH
   export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt4/plugins
@@ -66,22 +36,17 @@ fi
 export APP_DIR=$SNAP
 
 # Use GTK styling for running under Unity 7
-export GTK_PATH=$SNAP/usr/lib/$ARCH/gtk-2.0
+export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-2.0
 
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
-export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
-
+export GDK_PIXBUF_MODULEDIR=$RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
 if [ $needs_update = true ]; then
   rm -f $GDK_PIXBUF_MODULE_FILE
-  if [ -f $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
-    $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+  if [ -f $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+    $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
   fi
 fi
-
-# Keep an array of data dirs, for looping through them
-# Refresh it with potential new XDG_DATA_DIRS DIRS
-IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 
 # Icon themes cache
 if [ $needs_update = true ]; then
@@ -94,28 +59,15 @@ if [ $needs_update = true ]; then
         if [ ! -d "$theme_dir" ]; then
           mkdir -p "$theme_dir"
           ln -s $i/* "$theme_dir"
-          if [ -f $SNAP/usr/sbin/update-icon-caches ]; then
-            $SNAP/usr/sbin/update-icon-caches "$theme_dir"
-          elif [ -f $SNAP/usr/sbin/update-icon-cache.gtk2 ]; then
-            $SNAP/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
+          if [ -f $RUNTIME/usr/sbin/update-icon-caches ]; then
+            $RUNTIME/usr/sbin/update-icon-caches "$theme_dir"
+          elif [ -f $RUNTIME/usr/sbin/update-icon-cache.gtk2 ]; then
+            $RUNTIME/usr/sbin/update-icon-cache.gtk2 "$theme_dir"
           fi
         fi
       fi
     done
   done
-fi
-
-# compile real schema files now that we have the executable as part of the platform snap
-if [ "$USE_qt5appplatform" = true ]; then
-  if [ $needs_update = true ]; then
-    compile_giomodules $SNAP/ubuntu-app-platform/usr/lib/$ARCH
-    compile_schemas $SNAP/ubuntu-app-platform/usr/lib/$ARCH/glib-2.0/glib-compile-schemas
-  fi
-fi
-
-# Necessary for the SDK to find the translations directory
-if [ "$USE_qt5appplatform" = true ]; then
-  export APP_DIR=$SNAP
 fi
 
 exec "$@"

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -24,6 +24,7 @@ export QTCOMPOSE=$SNAP/usr/share/X11/locale
 if [ "$USE_qt5" = true ]; then
   export QT_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/qt5/plugins
   export QML2_IMPORT_PATH=$RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
+  [ "$USE_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
   if [ "$XDG_SESSION_TYPE" = "x11" ] ; then
     export QT_QPA_PLATFORM=xcb

--- a/qt/runtime-exports
+++ b/qt/runtime-exports
@@ -1,0 +1,16 @@
+#########################################
+# Ubuntu App platform runtime selection #
+#########################################
+
+if [ -d $SNAP/ubuntu-app-platform ]; then
+  RUNTIMEDIR=$SNAP/ubuntu-app-platform
+  if [ ! -d $RUNTIME/usr ] ; then
+    echo "You need to connect the ubuntu-app-platform package with your application "
+    echo "to reuse shared assets, please run:"
+    echo "snap install ubuntu-app-platform"
+    echo "snap connect $SNAP_NAME:platform ubuntu-app-platform:platform"
+    exit 1
+  fi
+  export QT_SELECT=snappy-qt5-app-platform
+fi
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -319,7 +319,7 @@ parts:
     source: .
     source-subdir: qt
     plugin: make
-    make-parameters: ["FLAVOR=qt5appplatform"]
+    make-parameters: ["FLAVOR=qt5"]
     # developer should use stable-phone-overlay PPA for Qt 5.6 to match the platform snap
     build-packages:
       - qtbase5-dev


### PR DESCRIPTION
Simplify and use RUNTIME refactoring by adding snap-specific libs to runtime ones.
Do it on both GTK and Qt sides.

Change slightly the logic by allowing generic init/runtime/generic desktop/specific desktop override order.