### PR TITLE
Export XLOCALEDIR to give XOpenIM a chance to locate locale data.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -17,7 +17,7 @@ export XKB_CONFIG_ROOT=$RUNTIME/usr/share/X11/xkb
 
 # Give XOpenIM a chance to locate locale data.
 # This is required for text input to work in SDL2 games.
-export XLOCALEDIR=$SNAP/usr/share/X11/locale
+export XLOCALEDIR=$RUNTIME/usr/share/X11/locale
 
 # Mesa Libs for OpenGL support
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/mesa

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -15,6 +15,10 @@ fi
 # XKB config
 export XKB_CONFIG_ROOT=$RUNTIME/usr/share/X11/xkb
 
+# Give XOpenIM a chance to locate locale data.
+# This is required for text input to work in SDL2 games.
+export XLOCALEDIR=$SNAP/usr/share/X11/locale
+
 # Mesa Libs for OpenGL support
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/mesa
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/mesa-egl


### PR DESCRIPTION
This is required for text input to work in SDL2 games.

Ref: https://lists.ubuntu.com/archives/snapcraft/2017-January/002699.html.