### PR TITLE
Support mir-libs content snap

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -43,6 +43,8 @@ if [ -d $SNAP/mir-libs/$ARCH ]; then
 elif [ -d $RUNTIME/usr/lib/$ARCH/mir ]; then
   # As of this writing, ubuntu-app-platform holds a copy of the Mir libraries,
   # but may remove them in favor of mir-libs.  Use them if present.
+  # We check both RUNTIME and SNAP (below) because if the SDK does drop the
+  # libraries, we want to fall back to an internal copy transparently.
   export MIR_CLIENT_PLATFORM_PATH=$RUNTIME/usr/lib/$ARCH/mir/client-platform
 else
   # Fall back to internal copy.

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -30,13 +30,23 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBGL_DRIVERS_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
 
 # Mir
-# Put mir-libs first because it's easy to end up with a snap-internal copy
-export LD_LIBRARY_PATH=$SNAP/mir-libs/$ARCH:$LD_LIBRARY_PATH
-export MIR_CLIENT_PLATFORM_PATH=$SNAP/mir-libs/$ARCH/mir/client-platform
-export MIR_SOCKET=/run/user/$(id -u)/mir_socket
-if [ ! -S "$MIR_SOCKET" -a -S /run/mir_socket ]; then
+if [ -S /run/user/$(id -u)/mir_socket ]; then
+  export MIR_SOCKET=/run/user/$(id -u)/mir_socket
+elif [ -S /run/mir_socket ]; then
   # Fall back to global location if there is no user server (e.g. on a kiosk)
   export MIR_SOCKET=/run/mir_socket
+fi
+if [ -d $SNAP/mir-libs/$ARCH ]; then
+  export MIR_CLIENT_PLATFORM_PATH=$SNAP/mir-libs/$ARCH/mir/client-platform
+  # Put mir-libs first because it's easy to end up with a snap-internal copy
+  export LD_LIBRARY_PATH=$SNAP/mir-libs/$ARCH:$LD_LIBRARY_PATH
+elif [ -d $RUNTIME/usr/lib/$ARCH/mir ]; then
+  # As of this writing, ubuntu-app-platform holds a copy of the Mir libraries,
+  # but may remove them in favor of mir-libs.  Use them if present.
+  export MIR_CLIENT_PLATFORM_PATH=$RUNTIME/usr/lib/$ARCH/mir/client-platform
+else
+  # Fall back to internal copy.
+  export MIR_CLIENT_PLATFORM_PATH=$SNAP/usr/lib/$ARCH/mir/client-platform
 fi
 
 # Unity7 export (workaround for https://launchpad.net/bugs/1638405)

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -30,7 +30,9 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBGL_DRIVERS_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
 
 # Mir
-export MIR_CLIENT_PLATFORM_PATH=$RUNTIME/usr/lib/$ARCH/mir/client-platform
+# Put mir-libs first because it's easy to end up with a snap-internal copy
+export LD_LIBRARY_PATH=$SNAP/mir-libs/$ARCH:$LD_LIBRARY_PATH
+export MIR_CLIENT_PLATFORM_PATH=$SNAP/mir-libs/$ARCH/mir/client-platform
 export MIR_SOCKET=/run/user/$(id -u)/mir_socket
 if [ ! -S "$MIR_SOCKET" -a -S /run/mir_socket ]; then
   # Fall back to global location if there is no user server (e.g. on a kiosk)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,6 +41,14 @@ description: |
                target: ubuntu-app-platform
          and then make your apps use it:
            plugs: [platform]
+       - access to Mir:
+           plugs:
+             mir:
+             mir-libs:
+               content: mir-libs
+               default-provider: mir-libs
+               interface: content
+               target: mir-libs
        - similarly for the gnome platform based apps
           plugs:
               gnome318-platform:
@@ -76,6 +84,9 @@ parts:
       - libgtk2.0-bin
       - unity-gtk2-module
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   gtk3:
     source: .
     source-subdir: gtk
@@ -95,6 +106,9 @@ parts:
       - libgtk-3-bin
       - unity-gtk3-module
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   qt4:
     source: .
     source-subdir: qt
@@ -114,6 +128,9 @@ parts:
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   qt5:
     source: .
     source-subdir: qt
@@ -133,6 +150,9 @@ parts:
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   glib-only:
     source: .
     source-subdir: glib-only
@@ -160,6 +180,9 @@ parts:
       - libgtk2.0-bin
       - unity-gtk2-module
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop/gtk3:
     source: .
     source-subdir: gtk
@@ -179,6 +202,9 @@ parts:
       - libgtk-3-bin
       - unity-gtk3-module
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop/qt4:
     source: .
     source-subdir: qt
@@ -198,6 +224,9 @@ parts:
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop/qt5:
     source: .
     source-subdir: qt
@@ -217,6 +246,9 @@ parts:
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop/glib-only:
     source: .
     source-subdir: glib-only
@@ -244,6 +276,9 @@ parts:
       - libgtk2.0-bin
       - unity-gtk2-module
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop-gtk3:
     source: .
     source-subdir: gtk
@@ -263,6 +298,9 @@ parts:
       - libgtk-3-bin
       - unity-gtk3-module
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop-qt4:
     source: .
     source-subdir: qt
@@ -282,6 +320,9 @@ parts:
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop-qt5:
     source: .
     source-subdir: qt
@@ -301,6 +342,9 @@ parts:
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
       - locales-all
+    prime:
+      - -usr/lib/*/libmir*
+      - -usr/share/doc/libmir*
   desktop-glib-only:
     source: .
     source-subdir: glib-only

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,7 +45,6 @@ description: |
            plugs:
              mir:
              mir-libs:
-               content: mir-libs
                default-provider: mir-libs
                interface: content
                target: mir-libs


### PR DESCRIPTION
So Mir support continues to evolve.  After some meetings, it's been determined that the mir-libs content snap is the only supported way of using Mir on snappy.  So let's point at it instead of u-a-p and set LD_LIBRARY_PATH accordingly.

I also skip including the Mir libs in consuming snaps without their knowledge.  It doesn't seem possible to avoid actually including the packages themselves (they are depends of gtk and qt), but we can easily avoid priming them.

See https://launchpad.net/bugs/1663048 for some context.