### PR TITLE
Adding support for testability

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -146,7 +146,6 @@ if [ ! -f $DCONF_DEST_USER_DIR/user ]; then
 fi
 
 # Testability support
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability/$ARCH
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability/$ARCH/mesa
-
+if [ -d "$SNAP/testability/$ARCH" ]; then
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability:$SNAP/testability/$ARCH:$SNAP/testability/$ARCH/mesa
+fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -144,3 +144,9 @@ if [ ! -f $DCONF_DEST_USER_DIR/user ]; then
     ln -s /home/$USER/.config/dconf/user $DCONF_DEST_USER_DIR
   fi
 fi
+
+# Testability support
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability/$ARCH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability/$ARCH/mesa
+


### PR DESCRIPTION
This PR updates LD_LIBRARY_PATH with the testability paths so that snaps can load the testability libraries and be introspected by autopilot. The testability libraries are provided by autopilot-qt snap using a content sharing interface