### PR TITLE
snapcraft.yaml: include libraries for indicators support

### DIFF
--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -28,11 +28,12 @@ if [ "$USE_qt5" = true ]; then
   export QT_PRINTER_MODULE=qtubuntu-print
   [ "$WITH_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
-  if [ -z "$DISPLAY" ] ; then
+  if [ -z "$DISPLAY" ] || [ -n "$MIR_SOCKET" ]; then
     export QT_QPA_PLATFORM=ubuntumirclient
   else
     # If a X11 $DISPLAY variable is set we should use it
     export QT_QPA_PLATFORM=xcb
+    export QT_QPA_PLATFORMTHEME=appmenu-qt5
   fi
 else
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/qt4

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       - libglib2.0-bin
       - libgtk2.0-bin
       - unity-gtk2-module
+      - libappindicator1
       - locales-all
     prime:
       - -usr/lib/*/libmir*
@@ -104,6 +105,7 @@ parts:
       - libglib2.0-bin
       - libgtk-3-bin
       - unity-gtk3-module
+      - libappindicator3-1
       - locales-all
     prime:
       - -usr/lib/*/libmir*
@@ -127,6 +129,7 @@ parts:
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
       - locales-all
+      - sni-qt
     prime:
       - -usr/lib/*/libmir*
       - -usr/share/doc/libmir*
@@ -178,6 +181,7 @@ parts:
       - libglib2.0-bin
       - libgtk2.0-bin
       - unity-gtk2-module
+      - libappindicator1
       - locales-all
     prime:
       - -usr/lib/*/libmir*
@@ -200,6 +204,7 @@ parts:
       - libglib2.0-bin
       - libgtk-3-bin
       - unity-gtk3-module
+      - libappindicator3-1
       - locales-all
     prime:
       - -usr/lib/*/libmir*
@@ -223,6 +228,7 @@ parts:
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
       - locales-all
+      - sni-qt
     prime:
       - -usr/lib/*/libmir*
       - -usr/share/doc/libmir*
@@ -275,6 +281,7 @@ parts:
       - libgtk2.0-bin
       - unity-gtk2-module
       - locales-all
+      - libappindicator1
     prime:
       - -usr/lib/*/libmir*
       - -usr/share/doc/libmir*
@@ -296,6 +303,7 @@ parts:
       - libglib2.0-bin
       - libgtk-3-bin
       - unity-gtk3-module
+      - libappindicator3-1
       - locales-all
     prime:
       - -usr/lib/*/libmir*
@@ -319,6 +327,7 @@ parts:
       - libqt4-svg # for loading icon themes which are svg
       - appmenu-qt
       - locales-all
+      - sni-qt
     prime:
       - -usr/lib/*/libmir*
       - -usr/share/doc/libmir*


### PR DESCRIPTION
This adds support to desktop indicators for snapped apps.