### PR TITLE
Don't set MIR_SOCKET=/run/mir_socket when not in kiosk mode

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -34,9 +34,13 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBGL_DRIVERS_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
 
 # Mir
-if [ -S /run/user/$(id -u)/mir_socket ]; then
+if [ -n "$DISPLAY" ]; then
+  # Either we are in legacy env (e.g. unity7) or ubuntu-app-launch is launching
+  # us intentionally in an XMir environment, in which case we should use it.
+  unset MIR_SOCKET
+elif [ -S /run/user/$(id -u)/mir_socket ]; then
   export MIR_SOCKET=/run/user/$(id -u)/mir_socket
-elif [ -S /run/mir_socket -a "$(id -u)" = "0" ]; then
+elif [ -S /run/mir_socket ]; then
   # Fall back to global location if there is no user server (e.g. on a kiosk)
   export MIR_SOCKET=/run/mir_socket
 fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -36,7 +36,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
 # Mir
 if [ -S /run/user/$(id -u)/mir_socket ]; then
   export MIR_SOCKET=/run/user/$(id -u)/mir_socket
-elif [ -S /run/mir_socket ]; then
+elif [ -S /run/mir_socket -a "$(id -u)" = "0" ]; then
   # Fall back to global location if there is no user server (e.g. on a kiosk)
   export MIR_SOCKET=/run/mir_socket
 fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -37,6 +37,8 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
 if [ -n "$DISPLAY" ]; then
   # Either we are in legacy env (e.g. unity7) or ubuntu-app-launch is launching
   # us intentionally in an XMir environment, in which case we should use it.
+  # Specifically unset because some versions of UAL unconditionally set
+  # MIR_SOCKET for us, even if launching us under XMir.
   unset MIR_SOCKET
 elif [ -S /run/user/$(id -u)/mir_socket ]; then
   export MIR_SOCKET=/run/user/$(id -u)/mir_socket


### PR DESCRIPTION
We currently have a bit of code to set MIR_SOCKET=/run/mir_socket if the user session doesn't have a socket.  This was intended to support kiosk-style snaps that don't run a full user session and just talk to the system Mir server directly.

However, this breaks in a couple places.  If MIR_SOCKET is set, some toolkits (Qt at least) will prefer to use it.  And ubuntu-app-launch unconditionally sets it when launching through it.  So a couple problems:

- When launching in unity7 directly (/snap/bin/testsnap) and USC happened to be running, we were setting MIR_SOCKET=/run/mir_socket [1], Qt then tried to talk to USC, and nothing ever was drawn.

- When launching via UAL in unity7 (whether USC was running or not), MIR_SOCKET was set by UAL to /run/user/XXX/mir_socket, Qt then tried to talk to a non-existent Mir server, and nothing was ever drawn.

In order to satisfy both those use cases and still support kiosk modes, I've added a check for DISPLAY.  If that's set, we assume we are in legacy mode or UAL has intentionally launched us in XMir mode (i.e. the snap doesn't declare a "mir" interface).  In both cases, we should not try to use Mir.  And thus I've added an 'unset' to undo UAL's misguided setting of MIR_SOCKET (which could probably be removed, but that's a separate issue).

[1] Because it was a valid socket, created by USC! We weren't smart enough to figure out we shouldn't use that before this PR