### PR TITLE
Fix docs for mir-libs connection

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,6 +48,7 @@ description: |
                default-provider: mir-libs
                interface: content
                target: mir-libs
+               content: mir0
        - similarly for the gnome platform based apps
           plugs:
               gnome318-platform:


### PR DESCRIPTION
The edge version of mir-libs now versions its interfaces.