### PR TITLE
Write the .last_revision stamp under $SNAP_USER_DATA.

### DIFF
--- a/common/init
+++ b/common/init
@@ -4,11 +4,11 @@
 
 needs_update=true
 
-. ~/.last_revision 2>/dev/null || true
+. $SNAP_USER_DATA/.last_revision 2>/dev/null || true
 if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
   needs_update=false
 fi
-[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > ~/.last_revision
+[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > $SNAP_USER_DATA/.last_revision
 
 if [ "$SNAP_ARCH" == "amd64" ]; then
   ARCH="x86_64-linux-gnu"

--- a/common/mark-and-exec
+++ b/common/mark-and-exec
@@ -2,6 +2,6 @@
 # Mark update and exec binary #
 ###############################
 
-[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > ~/.last_revision
+[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > $SNAP_USER_DATA/.last_revision
 
 exec "$@"


### PR DESCRIPTION
This ensures the desktop launchers can also be used with classic snaps.