### PR TITLE
prefer wayland if wayland detected and create compat symlink

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -82,6 +82,7 @@ if [ -n "$XDG_RUNTIME_DIR" ]; then
         #export WAYLAND_DEBUG=1
         export GDK_BACKEND="wayland"
         export CLUTTER_BACKEND="wayland"
+        export QT_QPA_PLATFORM="wayland-egl"
         # create the compat symlink for now
         if [ ! -e "$wayland_snappath" ]; then
             ln -s "$wayland_sockpath" "$wayland_snappath"

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -65,6 +65,30 @@ mkdir -p $XDG_CACHE_HOME
 # Create $XDG_RUNTIME_DIR if not exists (to be removed when LP: #1656340 is fixed)
 [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
 
+# If detect wayland server socket, then set environment so applications prefer
+# wayland, and setup compat symlink (until we use user mounts. Remember,
+# XDG_RUNTIME_DIR is /run/user/<uid>/snap.$SNAP so look in the parent directory
+# for the socket. For details:
+# https://forum.snapcraft.io/t/wayland-dconf-and-xdg-runtime-dir/186/10
+if [ -n "$XDG_RUNTIME_DIR" ]; then
+    wdisplay="wayland-0"
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+        wdisplay="$WAYLAND_DISPLAY"
+    fi
+    wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
+    wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
+    if [ -S "$wayland_sockpath" ]; then
+        # if running under wayland, use it
+        #export WAYLAND_DEBUG=1
+        export GDK_BACKEND="wayland"
+        export CLUTTER_BACKEND="wayland"
+        # create the compat symlink for now
+        if [ ! -e "$wayland_snappath" ]; then
+            ln -s "$wayland_sockpath" "$wayland_snappath"
+        fi
+    fi
+fi
+
 # GI repository
 export GI_TYPELIB_PATH=$RUNTIME/usr/lib/girepository-1.0:$RUNTIME/usr/lib/$ARCH/girepository-1.0
 [ "$WITH_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0 # add local SNAP assets if a runtime is used


### PR DESCRIPTION
If detect wayland server socket, then set environment so applications prefer wayland, and setup compat symlink (until we use user mounts. Remember, XDG_RUNTIME_DIR is /run/user/<uid>/snap.$SNAP so look in the parent directory for the socket. For details: https://forum.snapcraft.io/t/wayland-dconf-and-xdg-runtime-dir/186/10

Note, this might not be how the desktop team wants to detect and use wayland, but it does work. Quoting from the forum:

"I have tested this with:

- an updated gnome-sudoko with gnome-3-24 platform snap that uses a symlink from $XDG_RUNTIME_DIR/wayland-0 to $XDG_RUNTIME_DIR/../wayland-0 on 17.10
- an updated gnome-sudoko with gnome-3-24 platform snap that uses a symlink from $XDG_RUNTIME_DIR/wayland-0 to $XDG_RUNTIME_DIR/../wayland-0 on 17.04
- an updated gnome-logs-udt snap that uses a symlink from $XDG_RUNTIME_DIR/wayland-0 to $XDG_RUNTIME_DIR/../wayland-0 on 16.04

In all cases, if the wayland socket was detected, I'd set:

- export WAYLAND_DEBUG=1
- export GDK_BACKEND="wayland"
- export CLUTTER_BACKEND="wayland"

to force the use of wayland and would observe that wayland was used with no wayland server or client socket denials."

As such, feel free to take a different approach if you prefer. The important thing is that to use wayland today (future portals work may change this) you must set up the symlink to the wayland socket in the snap's XDG_RUNTIME_DIR.