### PR TITLE
update init to fix cases where the helper exits

### DIFF
--- a/common/init
+++ b/common/init
@@ -8,7 +8,6 @@ needs_update=true
 if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
   needs_update=false
 fi
-[ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > $SNAP_USER_DATA/.last_revision
 
 if [ "$SNAP_ARCH" == "amd64" ]; then
   ARCH="x86_64-linux-gnu"


### PR DESCRIPTION
When running the desktop-gnome-platform helper, it will exit part-way through if the platform interface isn't connected. Because the init part of the script is run before this then the needs_update/.last_revision will be set causing the helper to not compile the gnome schemas on the next launch, even if the platform interface is correctly connected. This causes gnome apps to die until either removed and reinstalled or an updated version is installed causing the .last_revision to no-longer match

this pr removes the setting of .last_revision in init deferring that to mark-and-exec.