### PR TITLE
adjust for new desktop interfaces

### DIFF
--- a/demos/gtk3/snapcraft.yaml
+++ b/demos/gtk3/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: strict
 apps:
   gtk3-demo:
     command: desktop-launch gtk3-demo
-    plugs: [unity7, x11, gsettings, home]
+    plugs: [desktop, desktop-legacy, wayland, unity7, gsettings, home]
   gsettings:
     command: desktop-launch gsettings
     plugs: [gsettings]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -22,14 +22,22 @@ description: |
        specify: "desktop-launch $SNAP/foo".
     3. add needed plugs to your application:
        - for graphical application:
-         plugs: [x11 (or unity7 for appmenu integration)]. Think about adding
-         opengl if you need hw acceleration.
+         plugs: [x11] or:
+                [unity7] for appmenu, input methods, a11y integration. And/or:
+                [desktop] for GNOME Shell/Plasma
+                [wayland] for Wayland compositors
+                See https://forum.snapcraft.io/t/the-desktop-interfaces/2042
+                for details
+       - if your application needs hw acceleration:
+         plugs: [opengl]
        - if your application needs access to sound:
          plugs: [pulseaudio]
        - accessing to user's home directory:
          plugs: [home]
        - read/write to gsettings:
          plugs: [gsettings]
+       - if using "desktop" and need a11y or other input methods:
+         plugs: [desktop-legacy]
        - use of the shared platform snap content, first define the plug:
            plugs:
              gnome-3-24-platform:


### PR DESCRIPTION
See https://forum.snapcraft.io/t/the-desktop-interfaces/2042 for details.

demos/gtk3/snapcraft.yaml:
- remove x11 (already included with unity7)
- add desktop, desktop-legacy and wayland

snapcraft.yaml: rephrase and update for desktop, desktop-legacy and wayland