### PR TITLE
Ensure XDG_CONFIG_HOME is set and run xdg-user-dirs-update

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -62,6 +62,15 @@ mkdir -p $XDG_DATA_HOME
 export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
 mkdir -p $XDG_CACHE_HOME
 
+# Set config folder to local path
+export XDG_CONFIG_HOME=$SNAP_USER_DATA/.config
+mkdir -p $XDG_CONFIG_HOME
+
+# Run xdg-user-dirs-update
+if [ `which xdg-user-dirs-update` ]; then
+   xdg-user-dirs-update
+fi
+
 # Create $XDG_RUNTIME_DIR if not exists (to be removed when LP: #1656340 is fixed)
 [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -172,6 +172,7 @@ parts:
       - unity-gtk2-module
       - locales-all
       - libappindicator1
+      - xdg-user-dirs
   desktop-gtk3:
     source: .
     source-subdir: gtk
@@ -217,6 +218,7 @@ parts:
       - appmenu-qt
       - locales-all
       - sni-qt
+      - xdg-user-dirs
   desktop-qt5:
     source: .
     source-subdir: qt
@@ -238,6 +240,7 @@ parts:
       - libqt5svg5 # for loading icon themes which are svg
       - appmenu-qt5
       - locales-all
+      - xdg-user-dirs
   desktop-glib-only:
     source: .
     source-subdir: glib-only

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -98,6 +98,7 @@ parts:
       - unity-gtk3-module
       - libappindicator3-1
       - locales-all
+      - xdg-user-dirs
   qt4:
     source: .
     source-subdir: qt
@@ -193,6 +194,7 @@ parts:
       - unity-gtk3-module
       - libappindicator3-1
       - locales-all
+      - xdg-user-dirs
   desktop-qt4:
     source: .
     source-subdir: qt


### PR DESCRIPTION
This fixes an issue with apps that use APIs such as  get_user_special_dir to get XDG_XXX_DIR locations.  This would be probably be better if we set XDG_XXX_DIR to directories of the host's homedir instead of in $SNAP_USER_DATA, however I don't see a way to get that dir.  I think this PR is a step in the right direction.