### PR TITLE
Forcibly remove gtk_config files if not symlinks

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -218,6 +218,7 @@ for f in ${gtk_configs[@]}; do
   if [ ! -L "$dest" ]
   then
     mkdir -p `dirname $dest`
+    [ -e "$dest" ] && rm -rf "$dest"
     ln -s /home/$USER/$f $dest
   fi
 done


### PR DESCRIPTION
The launcher tries to create symbolic links to GTK configuration files such as gtkfilechooser.ini. This process will fail and continue if the file exists, but is not already a symbolic link. This PR forcibly removes the file(s) if they are present, but not currently a symbolic link and then creates the link appropriately as before.

Once merged this PR will squash messages from `ln` like:
```plain
$ irccloud-desktop
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_GB.UTF-8)
ln: failed to create symbolic link '/home/dllewellyn/snap/irccloud-desktop/x2/.config/gtk-2.0/gtkfilechooser.ini': File exists
```