### PR TITLE
Mangle $SNAP to work around path issues on Fedora

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -4,10 +4,7 @@
 
 # On Fedora $SNAP is under /var and there is some magic to map it to /snap.
 # We need to handle that case and reset $SNAP
-if [[ $SNAP == /var/lib/snapd/* ]];
-then
-  SNAP=`echo $SNAP | sed -e "s|/var/lib/snapd||g"`
-fi
+SNAP=`echo $SNAP | sed -e "s|/var/lib/snapd||g"`
 
 WITH_RUNTIME=no
 if [ -z "$RUNTIME" ]; then

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -6,7 +6,7 @@
 # We need to handle that case and reset $SNAP
 if [[ $SNAP == /var/lib/snapd/* ]];
 then
-  export SNAP=`echo $SNAP | sed -e "s/\/var\/lib\/snapd//g"`
+  SNAP=`echo $SNAP | sed -e "s|/var/lib/snapd||g"`
 fi
 
 WITH_RUNTIME=no


### PR DESCRIPTION
On Fedora $SNAP is under /var and there is some magic to map it to /snap.  We need to handle that case and reset $SNAP
