### PR TITLE
Use caches from runtime if they exist

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -2,13 +2,30 @@
 # Launcher common exports for any desktop app #
 ###############################################
 
+function prepend_dir() {
+  local var="$1"
+  local dir="$2"
+  if [ -d "$dir" ]; then
+    eval "export $var=\"\$dir\${$var:+:\$$var}\""
+  fi
+}
+
+function append_dir() {
+  local var="$1"
+  local dir="$2"
+  if [ -d "$dir" ]; then
+    eval "export $var=\"\${$var:+\$$var:}\$dir\""
+  fi
+}
+
 WITH_RUNTIME=no
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
 else
   # add general paths not added by snapcraft due to runtime snap
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH
-  export PATH=$PATH:$RUNTIME/usr/bin
+  append_dir LD_LIBRARY_PATH $RUNTIME/lib/$ARCH
+  append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH
+  append_dir PATH $RUNTIME/usr/bin
   WITH_RUNTIME=yes
 fi
 
@@ -20,24 +37,24 @@ export XKB_CONFIG_ROOT=$RUNTIME/usr/share/X11/xkb
 export XLOCALEDIR=$RUNTIME/usr/share/X11/locale
 
 # Mesa Libs for OpenGL support
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/mesa
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/mesa-egl
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa-egl
 
 # Tell libGL where to find the drivers
 export LIBGL_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBGL_DRIVERS_PATH
+append_dir LD_LIBRARY_PATH $LIBGL_DRIVERS_PATH
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
 # Without that OpenGL using apps do not work with the nVidia drivers.
 # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/lib/snapd/lib/gl
+append_dir LD_LIBRARY_PATH /var/lib/snapd/lib/gl
 
 # Unity7 export (workaround for https://launchpad.net/bugs/1638405)
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/libunity
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/libunity
 
 # Pulseaudio export
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUNTIME/usr/lib/$ARCH/pulseaudio
+append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/pulseaudio
 
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
@@ -46,16 +63,16 @@ export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
 export GST_PLUGIN_SCANNER=$RUNTIME/usr/lib/$ARCH/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
 
 # XDG Config
-export XDG_CONFIG_DIRS=$RUNTIME/etc/xdg:$RUNTIME/usr/xdg:$XDG_CONFIG_DIRS
-[ "$WITH_RUNTIME" = yes ] && XDG_CONFIG_DIRS=$SNAP/etc/xdg:$SNAP/usr/xdg:$XDG_CONFIG_DIRS # add local SNAP assets if a runtime is used
+[ "$WITH_RUNTIME" = yes ] && prepend_dir XDG_CONFIG_DIRS $RUNTIME/etc/xdg
+prepend_dir XDG_CONFIG_DIRS $SNAP/etc/xdg
 
 # Define snaps' own data dir
-export XDG_DATA_DIRS=$SNAP_USER_DATA:$RUNTIME/usr/share:$XDG_DATA_DIRS
-[ "$WITH_RUNTIME" = yes ] && XDG_DATA_DIRS=$SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS # add local SNAP assets if a runtime is used
+[ "$WITH_RUNTIME" = yes ] && prepend_dir XDG_DATA_DIRS $RUNTIME/usr/share
+prepend_dir XDG_DATA_DIRS $SNAP/usr/share
+prepend_dir XDG_DATA_DIRS $SNAP_USER_DATA
 
 # Set XDG_DATA_HOME to local path
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
-export XDG_DATA_DIRS=$XDG_DATA_HOME:$XDG_DATA_DIRS
 mkdir -p $XDG_DATA_HOME
 
 # Set cache folder to local path
@@ -100,8 +117,11 @@ if [ -n "$XDG_RUNTIME_DIR" ]; then
 fi
 
 # GI repository
-export GI_TYPELIB_PATH=$RUNTIME/usr/lib/girepository-1.0:$RUNTIME/usr/lib/$ARCH/girepository-1.0
-[ "$WITH_RUNTIME" = yes ] && GI_TYPELIB_PATH=$SNAP/usr/lib/gjs/girepository-1.0:$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0 # add local SNAP assets if a runtime is used
+[ "$WITH_RUNTIME" = yes ] && prepend_dir GI_TYPELIB_PATH $RUNTIME/usr/lib/$ARCH/girepository-1.0
+[ "$WITH_RUNTIME" = yes ] && prepend_dir GI_TYPELIB_PATH $RUNTIME/usr/lib/girepository-1.0
+prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/$ARCH/girepository-1.0
+prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/girepository-1.0
+prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/gjs/girepository-1.0
 
 # Font Config and themes
 export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d
@@ -125,7 +145,7 @@ if [ $needs_update = true ]; then
 fi
 
 # Ensure the app finds locale definitions (requires locales-all to be installed)
-export LOCPATH=$LOCPATH:$SNAP/usr/lib/locale
+append_dir LOCPATH $SNAP/usr/lib/locale
 
 # Gio modules and cache (including gsettings module)
 export GIO_MODULE_DIR=$XDG_CACHE_HOME/gio-modules
@@ -177,9 +197,9 @@ if [ ! -f $DCONF_DEST_USER_DIR/user ]; then
 fi
 
 # Testability support
-if [ -d "$SNAP/testability/$ARCH" ]; then
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/testability:$SNAP/testability/$ARCH:$SNAP/testability/$ARCH/mesa
-fi
+append_dir LD_LIBRARY_PATH $SNAP/testability
+append_dir LD_LIBRARY_PATH $SNAP/testability/$ARCH
+append_dir LD_LIBRARY_PATH $SNAP/testability/$ARCH/mesa
 
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -226,7 +226,7 @@ if [ $needs_update = true ]; then
   mkdir -p $XDG_DATA_HOME/icons
   for d in "${data_dirs_array[@]}"; do
     for i in $d/icons/*; do
-      if [ -d "$i" ]; then
+      if [ -f "$i/index.theme" -a ! -f "$i/icon-theme.cache" ]; then
         theme_dir=$XDG_DATA_HOME/icons/$(basename "$i")
         if [ ! -d "$theme_dir" ]; then
           mkdir -p "$theme_dir"

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -138,9 +138,11 @@ fi
 # needed for gtk and qt icon
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/mime
-  if [ `which update-mime-database` ]; then
-    cp --preserve=timestamps -dR $RUNTIME/usr/share/mime $XDG_DATA_HOME
-    update-mime-database $XDG_DATA_HOME/mime
+  if [ ! -f $RUNTIME/usr/share/mime/mime.cache ]; then
+    if [ `which update-mime-database` ]; then
+      cp --preserve=timestamps -dR $RUNTIME/usr/share/mime $XDG_DATA_HOME
+      update-mime-database $XDG_DATA_HOME/mime
+    fi
   fi
 fi
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -172,14 +172,21 @@ function compile_schemas {
     mkdir -p $GS_SCHEMA_DIR
     for d in "${data_dirs_array[@]}"; do
       schema_dir=$d/glib-2.0/schemas
-      if [ "$(ls -A $schema_dir/*.xml 2>/dev/null)" ]; then
+      if [ -f "$schema_dir/gschemas.compiled" ]; then
+        # This directory already has compiled schemas
+        continue
+      fi
+      if [ -n "$(ls -A $schema_dir/*.xml 2>/dev/null)" ]; then
         ln -s $schema_dir/*.xml $GS_SCHEMA_DIR
       fi
-      if [ "$(ls -A $schema_dir/*.override 2>/dev/null)" ]; then
+      if [ -n "$(ls -A $schema_dir/*.override 2>/dev/null)" ]; then
         ln -s $schema_dir/*.override $GS_SCHEMA_DIR
       fi
     done
-    "$1" $GS_SCHEMA_DIR
+    # Only compile schemas if we copied anyting
+    if [ -n "$(ls -A $GS_SCHEMA_DIR/*.xml $GS_SCHEMA_DIR/*.override 2>/dev/null)" ]; then
+      "$1" $GS_SCHEMA_DIR
+    fi
   fi
 }
 if [ $needs_update = true ]; then


### PR DESCRIPTION
Currently desktop-launch builds caches for a number of things the first time a snapped app is run (gsettings schemas, mime database, icon theme caches, etc).  Some of these operations are quite expensive, so it would be nice to avoid it if possible.

This branch makes a number of changes towards this goal:

1. If a schema dir on $XDG_DATA_DIRS has a `gschemas.compiled` file, don't symlink its schemas to $XDG_DATA_HOME.  Further more, if we don't symlink any schemas, don't run glib-compile-schemas.

2. If a mime.cache file exists in the snap, don't copy the mime database or run update-mime-database.

3. If an icon theme has an icon-theme.cache file, don't symlink it $XDG_DATA_HOME or run update-icon-caches.

Of these, (2) is the most noticeable.  So that this actually does something, the `gnome-3-26-1604` snap on edge channel has been updated to include these caches.

There are a few other changes in here too:

1. stop adding non-existent directories to search path environment variables
2. don't put $XDG_DATA_HOME on $XDG_DATA_DIRS: this is unnecessary.