### PR TITLE
common: add $XDG_DATA_HOME back to $XDG_DATA_DIRS: it is needed for GSettings with old GLib

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -75,6 +75,10 @@ prepend_dir XDG_DATA_DIRS $SNAP_USER_DATA
 export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
 mkdir -p $XDG_DATA_HOME
 
+# Workaround for GLib < 2.53.2 not searching for schemas in $XDG_DATA_HOME:
+#   https://bugzilla.gnome.org/show_bug.cgi?id=741335
+prepend_dir XDG_DATA_DIRS $XDG_DATA_HOME
+
 # Set cache folder to local path
 export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
 mkdir -p $XDG_CACHE_HOME


### PR DESCRIPTION
This PR reverts one of the changes from #86: it prepends $XDG_DATA_HOME to $XDG_DATA_DIRS again.

According to the spec, this shouldn't be needed, but older versions of GLib (such as the one in Ubuntu 16.04) don't check for schemas in $XDG_DATA_HOME:

https://bugzilla.gnome.org/show_bug.cgi?id=741335

This didn't show up when testing with the gnome platform snap, since that contains a new enough version of GLib.