### PR TITLE
common/desktop-exports: make PulseAudio socket available in snap-specific XDG_RUNTIME_DIR

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -126,12 +126,8 @@ fi
 if [ -n "$XDG_RUNTIME_DIR" ]; then
     pulsenative="pulse/native"
     pulseaudio_sockpath="$XDG_RUNTIME_DIR/../$pulsenative"
-    pulseaudio_snappath="$XDG_RUNTIME_DIR/$pulsenative"
     if [ -S "$pulseaudio_sockpath" ]; then
-        if [ ! -e "$pulseaudio_snappath" ]; then
-            mkdir -p -m 700 $(dirname "$pulseaudio_snappath")
-            ln -s "$pulseaudio_sockpath" "$pulseaudio_snappath"
-        fi
+        export PULSE_SERVER="unix:${pulseaudio_sockpath}"
     fi
 fi
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -122,6 +122,19 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     fi
 fi
 
+# Make PulseAudio socket available inside the snap-specific $XDG_RUNTIME_DIR
+if [ -n "$XDG_RUNTIME_DIR" ]; then
+    pulsenative="pulse/native"
+    pulseaudio_sockpath="$XDG_RUNTIME_DIR/../$pulsenative"
+    pulseaudio_snappath="$XDG_RUNTIME_DIR/$pulsenative"
+    if [ -S "$pulseaudio_sockpath" ]; then
+        if [ ! -e "$pulseaudio_snappath" ]; then
+            mkdir -p -m 700 $(dirname "$pulseaudio_snappath")
+            ln -s "$pulseaudio_sockpath" "$pulseaudio_snappath"
+        fi
+    fi
+fi
+
 # GI repository
 [ "$WITH_RUNTIME" = yes ] && prepend_dir GI_TYPELIB_PATH $RUNTIME/usr/lib/$ARCH/girepository-1.0
 [ "$WITH_RUNTIME" = yes ] && prepend_dir GI_TYPELIB_PATH $RUNTIME/usr/lib/girepository-1.0


### PR DESCRIPTION
Applications using libpulse (eg. Spotify, VLC) will probe
$XDG_RUNTIME_DIR/pulse/native as one of locations where PulseAudio socket may be
available.

In case of snaps, the XDG_RUNTIME_DIR is set to /run/user/$(id -u)/snap.<snap>.
If PulseAudio has a socket in the original $XDG_RUNTIME_DIR, make sure that it's
also available in snap-specific one.