### PR TITLE
Use the locales from the gnome-platform

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -86,7 +86,7 @@ if [ $needs_update = true ]; then
 fi
 
 # Ensure the app finds locale definitions (requires locales-all to be installed)
-export LOCPATH=$SNAP/usr/lib/locale
+export LOCPATH=$RUNTIME/usr/lib/locale
 
 # Gio modules and cache (including gsettings module)
 export GIO_MODULE_DIR=$XDG_CACHE_HOME/gio-modules


### PR DESCRIPTION
The gnome-platform snap includes the locales definition, look at the correct location and fixes translations.