### PR TITLE
Use the locales definition from the gnome-platform

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -192,7 +192,7 @@ if [ $needs_update = true ]; then
 fi
 
 # Ensure the app finds locale definitions (requires locales-all to be installed)
-append_dir LOCPATH $SNAP/usr/lib/locale
+append_dir LOCPATH $RUNTIME/usr/lib/locale
 
 # Gio modules and cache (including gsettings module)
 export GIO_MODULE_DIR=$XDG_CACHE_HOME/gio-modules


### PR DESCRIPTION
The gnome-platform snap includes locales definition, use those and fix translations.