### PR TITLE
Added test-gsettings snaps for gtk3 and gnome launchers

### DIFF
--- a/tests/snaps/test-desktop-helpers-gnome/snapcraft.yaml
+++ b/tests/snaps/test-desktop-helpers-gnome/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: test-desktop-helpers-gnome
+version: git
+summary: Test for desktop helpers gnome launcher
+description: |
+  A test program for desktop helpers gnome launcher
+grade: devel
+confinement: strict
+
+plugs:
+  gnome-3-26-1604:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-26-1604:gnome-3-26-1604
+
+apps:
+  test-gsettings:
+    command: bin/desktop-launch $SNAP/test-gsettings
+    plugs:
+      - gsettings
+      - desktop
+
+parts:
+  desktop-gnome-platform:
+    source: ../../../
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - libgtk-3-dev
+    install: mkdir -p $SNAPCRAFT_PART_INSTALL/gnome-platform
+
+  test-gsettings:
+    after: [desktop-gnome-platform]
+    plugin: nil
+    source: .
+    install: |
+      gcc -o $SNAPCRAFT_PART_INSTALL/test-gsettings -O2 -Wall test-gsettings.c `pkg-config --cflags --libs gio-2.0`
+    build-packages:
+      - gcc
+      - libglib2.0-dev
+      - pkg-config

--- a/tests/snaps/test-desktop-helpers-gnome/test-gsettings.c
+++ b/tests/snaps/test-desktop-helpers-gnome/test-gsettings.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <glib.h>
+#include <gio/gio.h>
+
+int main (int argc, char **argv)
+{
+	gint result = 0;
+	const gchar *schema_id = "org.gnome.desktop.interface";
+	const gchar *key = "gtk-theme";
+	if (argc > 1 && argv[1] != NULL)
+			schema_id = g_strdup (argv[1]);
+	if (argc > 2 && argv[2] != NULL)
+		key = g_strdup (argv[2]);
+
+	GSettings *settings = g_settings_new (schema_id);
+	gchar *value = g_settings_get_string (settings, key);
+
+	g_print("Schema: %s Key: %s Value: %s\n", schema_id, key, value);
+	return result;
+}

--- a/tests/snaps/test-desktop-helpers-gtk3/snapcraft.yaml
+++ b/tests/snaps/test-desktop-helpers-gtk3/snapcraft.yaml
@@ -1,0 +1,50 @@
+name: test-desktop-helpers-gtk3
+version: git
+summary: Test for desktop helpers gtk3 launcher
+description: |
+  A test program for desktop helpers gtk3 launcher
+grade: devel
+confinement: strict
+
+apps:
+  test-gsettings:
+    command: bin/desktop-launch $SNAP/test-gsettings
+    plugs:
+      - gsettings
+      - desktop
+
+parts:
+  desktop-gtk3:
+    source: ../../../
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - libgtk-3-dev
+    stage-packages:
+      - libxkbcommon0  # XKB_CONFIG_ROOT
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libgtk-3-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk-3-bin
+      - unity-gtk3-module
+      - libappindicator3-1
+      - locales-all
+      - xdg-user-dirs
+
+  test-gsettings:
+    after: [desktop-gtk3]
+    plugin: nil
+    source: .
+    install: |
+      gcc -o $SNAPCRAFT_PART_INSTALL/test-gsettings -O2 -Wall test-gsettings.c `pkg-config --cflags --libs gio-2.0`
+    build-packages:
+      - gcc
+      - libglib2.0-dev
+      - pkg-config

--- a/tests/snaps/test-desktop-helpers-gtk3/test-gsettings.c
+++ b/tests/snaps/test-desktop-helpers-gtk3/test-gsettings.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <glib.h>
+#include <gio/gio.h>
+
+int main (int argc, char **argv)
+{
+	gint result = 0;
+	const gchar *schema_id = "org.gnome.desktop.interface";
+	const gchar *key = "gtk-theme";
+	if (argc > 1 && argv[1] != NULL)
+			schema_id = g_strdup (argv[1]);
+	if (argc > 2 && argv[2] != NULL)
+		key = g_strdup (argv[2]);
+
+	GSettings *settings = g_settings_new (schema_id);
+	gchar *value = g_settings_get_string (settings, key);
+
+	g_print("Schema: %s Key: %s Value: %s\n", schema_id, key, value);
+	return result;
+}


### PR DESCRIPTION
Adds a couple of test snaps which exercise bits of the helpers.  We need to continue to grow this selection, but it's a start.