### PR TITLE
Set XCURSOR_PATH to proper folder to use properly themed pointer cursors

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -36,6 +36,9 @@ export XKB_CONFIG_ROOT=$RUNTIME/usr/share/X11/xkb
 # This is required for text input to work in SDL2 games.
 export XLOCALEDIR=$RUNTIME/usr/share/X11/locale
 
+# Set XCursors path
+export XCURSOR_PATH=$RUNTIME/usr/share/icons
+
 # Mesa Libs for OpenGL support
 append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa
 append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa-egl


### PR DESCRIPTION
This issue is there for too long time, by defining `XCURSOR_PATH` to proper folder, we can use installed cursor themes to match system, instead of the default ugly X11 cursors.

To test this you can just try it on already available snaps by doing something like:

`snap=spotify; env XCURSOR_PATH=/snap/$snap/current/usr/share/icons snap run $snap`