### PR TITLE
Move XDG_CACHE_HOME to $SNAP_USER_COMMON/.cache.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -84,6 +84,10 @@ prepend_dir XDG_DATA_DIRS $XDG_DATA_HOME
 
 # Set cache folder to local path
 export XDG_CACHE_HOME=$SNAP_USER_COMMON/.cache
+if [[ -d $SNAP_USER_DATA/.cache && ! -e $XDG_CACHE_HOME ]]; then
+  # the .cache directory used to be stored under $SNAP_USER_DATA, migrate it
+  mv $SNAP_USER_DATA/.cache $SNAP_USER_COMMON/
+fi
 mkdir -p $XDG_CACHE_HOME
 
 # Set config folder to local path

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -83,7 +83,7 @@ mkdir -p $XDG_DATA_HOME
 prepend_dir XDG_DATA_DIRS $XDG_DATA_HOME
 
 # Set cache folder to local path
-export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
+export XDG_CACHE_HOME=$SNAP_USER_COMMON/.cache
 mkdir -p $XDG_CACHE_HOME
 
 # Set config folder to local path


### PR DESCRIPTION
This will ensure that non-essential cached files are not copied back and forth upon {up,down}grade of snaps.