### PR TITLE
Create links to xdg user dirs under the snap's $HOME

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -107,8 +107,8 @@ test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:
 XDG_SPECIAL_DIRS=($XDG_DOCUMENTS_DIR $XDG_DESKTOP_DIR $XDG_DOWNLOAD_DIR $XDG_MUSIC_DIR $XDG_PICTURES_DIR $XDG_VIDEOS_DIR $XDG_PUBLIC_DIR $XDG_TEMPLATES_DIR)
 for d in ${XDG_SPECIAL_DIRS[@]}; do
   b=$(basename "$d")
-    if [ -e $REALHOME/$b ] && [ ! -e $SNAP_USER_DATA/$b ]; then
-      ln -s $REALHOME/$b $SNAP_USER_DATA/$b
+    if [ -e $REALHOME/$b ] && [ ! -e $HOME/$b ]; then
+      ln -s $REALHOME/$b $HOME/$b
     fi
 done
 


### PR DESCRIPTION
Create links to xdg user dirs under the snap's $HOME instead of expecting it under $SNAP_USER_DATA.  This fixes linking the appropriate directory regardless of the snap having $HOME set to $SNAP_USER_DATA or $SNAP_USER_COMMON.