### PR TITLE
If the user-dirs.* exists in the $REALHOME, link them into the snap's XDG_CONFIG_HOME.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -134,7 +134,7 @@ for d in ${XDG_SPECIAL_DIRS[@]}; do
 done
 
 # If needs XDG update and xdg-user-dirs-update exists in $PATH, run it
-if [ $needs_xdg_update = true && `which xdg-user-dirs-update` ]; then
+if [ $needs_xdg_update = true ] && [ `which xdg-user-dirs-update` ]; then
    xdg-user-dirs-update
 fi
     

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -119,7 +119,7 @@ if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/
    for f in user-dirs.dirs user-dirs.locale; do
      md5sum < $REALHOME/.config/$f > $HOME/.config/$f.md5sum
    done
-else;
+else
    needs_xdg_update=true
    needs_xdg_links=true
 fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -114,7 +114,7 @@ done
 needs_xdg_update=false
 needs_xdg_links=false
 if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
-   sed s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
+   sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
    cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
    for f in user-dirs.dirs user-dirs.locale; do
      md5sum < $REALHOME/.config/$f > $HOME/.config/$f.md5sum

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -104,6 +104,14 @@ mkdir -p $XDG_CONFIG_HOME
 # Ensure the app finds locale definitions (requires locales-all to be installed)
 append_dir LOCPATH $RUNTIME/usr/lib/locale
 
+# If any, keep track of where XDG dirs were so we can potentially migrate the content later
+test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
+for link in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
+  eval $(echo "OLD_XDG_${link}_DIR")=`eval "$(echo "echo \\$XDG_${link}_DIR")"`
+  # Echo for debugging
+  echo OLD_XDG_${link}_DIR=`eval $(echo "echo \\$XDG_${link}_DIR")`
+done
+
 # Setup user-dirs.* or run xdg-user-dirs-update if needed
 needs_xdg_update=false
 needs_xdg_links=false
@@ -140,6 +148,25 @@ if [ $needs_xdg_links = true ]; then
     b=$(basename "$d")
     if [ -e $REALHOME/$b ] && [ ! -e $HOME/$b ]; then
       ln -s $REALHOME/$b $HOME/$b
+    fi
+  done
+else
+  # If we aren't creating new links, check if we have content saved in old locations and move it
+  for link in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
+    echo $link
+    old=`eval "$(echo "echo \\$OLD_XDG_${link}_DIR")"`
+    new=`eval "$(echo "echo \\$XDG_${link}_DIR")"`
+    if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ]; then
+      # Echo for debugging
+      echo "$old" is not "$new", migrating content
+      mv "$old"/* "$new"/
+    elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ]; then
+      # Echo for debugging
+      echo "$old" is not "$new", migrating content
+      mv "$old"/* "$new"/
+    else
+      # Echo for debugging
+      echo "$old" is "$new", not migrating content
     fi
   done
 fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -22,8 +22,6 @@ function can_open_file() {
   return `head -c0 "$1" &> /dev/null`;
 }
 
-REALHOME=`getent passwd $UID | cut -d ':' -f 6`
-
 WITH_RUNTIME=no
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
@@ -111,6 +109,9 @@ needs_xdg_links=false
 if can_open_file $REALHOME/.config/user-dirs.dirs && can_open_file $REALHOME/.config/user-dirs.locale; then
    cat $REALHOME/.config/user-dirs.dirs | sed -e s#\$HOME#${REALHOME}# > $HOME/.config/user-dirs.dirs
    cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
+   for f in user-dirs.dirs user-dirs.locale; do
+     md5sum < $REALHOME/.config/$f > $HOME/.config/$f.md5sum
+   done
 elif [ `which xdg-user-dirs-update` ]; then
    xdg-user-dirs-update
    needs_xdg_links=true

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -103,7 +103,10 @@ mkdir -p $XDG_CONFIG_HOME
 append_dir LOCPATH $RUNTIME/usr/lib/locale
 
 # Run xdg-user-dirs-update
-if [ `which xdg-user-dirs-update` ]; then
+if [ -f $REALHOME/.config/user-dirs.dirs ] && [ -f $REALHOME/.config/user-dirs.locale ]; then
+   ln -s $REALHOME/.config/user-dirs.dirs $HOME/.config/
+   ln -s $REALHOME/.config/user-dirs.locale $HOME/.config/
+elif [ `which xdg-user-dirs-update` ]; then
    xdg-user-dirs-update
 fi
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -107,7 +107,7 @@ append_dir LOCPATH $RUNTIME/usr/lib/locale
 # Setup user-dirs.* or run xdg-user-dirs-update if needed
 needs_xdg_links=false
 if can_open_file $REALHOME/.config/user-dirs.dirs && can_open_file $REALHOME/.config/user-dirs.locale; then
-   cat $REALHOME/.config/user-dirs.dirs | sed -e s#\$HOME#${REALHOME}# > $HOME/.config/user-dirs.dirs
+   sed s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
    cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
    for f in user-dirs.dirs user-dirs.locale; do
      md5sum < $REALHOME/.config/$f > $HOME/.config/$f.md5sum

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -105,18 +105,33 @@ mkdir -p $XDG_CONFIG_HOME
 append_dir LOCPATH $RUNTIME/usr/lib/locale
 
 # Setup user-dirs.* or run xdg-user-dirs-update if needed
+needs_xdg_update=false
 needs_xdg_links=false
-if can_open_file $REALHOME/.config/user-dirs.dirs && can_open_file $REALHOME/.config/user-dirs.locale; then
+if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
    sed s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
    cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
    for f in user-dirs.dirs user-dirs.locale; do
      md5sum < $REALHOME/.config/$f > $HOME/.config/$f.md5sum
    done
-elif [ `which xdg-user-dirs-update` ]; then
-   xdg-user-dirs-update
+else;
+   needs_xdg_update=true
    needs_xdg_links=true
 fi
 
+# Check if we can actually read the contents of each xdg dir
+test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
+XDG_SPECIAL_DIRS=($XDG_DOCUMENTS_DIR $XDG_DESKTOP_DIR $XDG_DOWNLOAD_DIR $XDG_MUSIC_DIR $XDG_PICTURES_DIR $XDG_VIDEOS_DIR $XDG_PUBLIC_DIR $XDG_TEMPLATES_DIR)
+for d in ${XDG_SPECIAL_DIRS[@]}; do
+  if ! can_open_file $d; then
+    needs_xdg_update=true
+  fi
+done
+
+# If needs XDG update and xdg-user-dirs-update exists in $PATH, run it
+if [ $needs_xdg_update = true && `which xdg-user-dirs-update` ]; then
+   xdg-user-dirs-update
+fi
+    
 # Create links for user-dirs.dirs
 if [ $needs_xdg_links = true ]; then
   test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -18,6 +18,10 @@ function append_dir() {
   fi
 }
 
+function can_open_file() {
+  return `head -c0 "$1" &> /dev/null`;
+}
+
 REALHOME=`getent passwd $UID | cut -d ':' -f 6`
 
 WITH_RUNTIME=no
@@ -102,23 +106,27 @@ mkdir -p $XDG_CONFIG_HOME
 # Ensure the app finds locale definitions (requires locales-all to be installed)
 append_dir LOCPATH $RUNTIME/usr/lib/locale
 
-# Run xdg-user-dirs-update
-if [ -f $REALHOME/.config/user-dirs.dirs ] && [ -f $REALHOME/.config/user-dirs.locale ]; then
-   ln -s $REALHOME/.config/user-dirs.dirs $HOME/.config/
-   ln -s $REALHOME/.config/user-dirs.locale $HOME/.config/
+# Setup user-dirs.* or run xdg-user-dirs-update if needed
+needs_xdg_links=false
+if can_open_file $REALHOME/.config/user-dirs.dirs && can_open_file $REALHOME/.config/user-dirs.locale; then
+   cat $REALHOME/.config/user-dirs.dirs | sed -e s#\$HOME#${REALHOME}# > $HOME/.config/user-dirs.dirs
+   cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
 elif [ `which xdg-user-dirs-update` ]; then
    xdg-user-dirs-update
+   needs_xdg_links=true
 fi
 
 # Create links for user-dirs.dirs
-test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
-XDG_SPECIAL_DIRS=($XDG_DOCUMENTS_DIR $XDG_DESKTOP_DIR $XDG_DOWNLOAD_DIR $XDG_MUSIC_DIR $XDG_PICTURES_DIR $XDG_VIDEOS_DIR $XDG_PUBLIC_DIR $XDG_TEMPLATES_DIR)
-for d in ${XDG_SPECIAL_DIRS[@]}; do
-  b=$(basename "$d")
+if [ $needs_xdg_links = true ]; then
+  test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
+  XDG_SPECIAL_DIRS=($XDG_DOCUMENTS_DIR $XDG_DESKTOP_DIR $XDG_DOWNLOAD_DIR $XDG_MUSIC_DIR $XDG_PICTURES_DIR $XDG_VIDEOS_DIR $XDG_PUBLIC_DIR $XDG_TEMPLATES_DIR)
+  for d in ${XDG_SPECIAL_DIRS[@]}; do
+    b=$(basename "$d")
     if [ -e $REALHOME/$b ] && [ ! -e $HOME/$b ]; then
       ln -s $REALHOME/$b $HOME/$b
     fi
-done
+  done
+fi
 
 # If detect wayland server socket, then set environment so applications prefer
 # wayland, and setup compat symlink (until we use user mounts. Remember,

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -154,9 +154,9 @@ else
     old=`eval "$(echo "echo \\$OLD_XDG_${d}_DIR")"`
     new=`eval "$(echo "echo \\$XDG_${d}_DIR")"`
     if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ]; then
-      mv "$old"/* "$new"/
+      mv "$old"/* "$new"/ 2>/dev/null
     elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ]; then
-      mv "$old"/* "$new"/
+      mv "$old"/* "$new"/ 2>/dev/null
     fi
   done
 fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -314,3 +314,11 @@ for f in ${gtk_configs[@]}; do
     ln -s $REALHOME/$f $dest
   fi
 done
+
+# create symbolic link to ibus socket path for ibus to look up its socket files
+# (see comments #3 and #6 on https://launchpad.net/bugs/1580463)
+IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
+mkdir -p $IBUS_CONFIG_PATH
+[ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
+ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
+

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -143,7 +143,7 @@ if [ $needs_xdg_links = true ]; then
   test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
   XDG_SPECIAL_DIRS=($XDG_DOCUMENTS_DIR $XDG_DESKTOP_DIR $XDG_DOWNLOAD_DIR $XDG_MUSIC_DIR $XDG_PICTURES_DIR $XDG_VIDEOS_DIR $XDG_PUBLIC_DIR $XDG_TEMPLATES_DIR)
   for d in ${XDG_SPECIAL_DIRS[@]}; do
-    b=$(basename "$d")
+    b=$(realpath "$d" --relative-to="$REALHOME")
     if [ -e $REALHOME/$b ] && [ ! -e $HOME/$b ]; then
       ln -s $REALHOME/$b $HOME/$b
     fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -106,8 +106,8 @@ append_dir LOCPATH $RUNTIME/usr/lib/locale
 
 # If any, keep track of where XDG dirs were so we can potentially migrate the content later
 test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
-for link in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
-  eval $(echo "OLD_XDG_${link}_DIR")=`eval "$(echo "echo \\$XDG_${link}_DIR")"`
+for d in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
+  eval $(echo "OLD_XDG_${d}_DIR")=`eval "$(echo "echo \\$XDG_${d}_DIR")"`
 done
 
 # Setup user-dirs.* or run xdg-user-dirs-update if needed
@@ -150,10 +150,9 @@ if [ $needs_xdg_links = true ]; then
   done
 else
   # If we aren't creating new links, check if we have content saved in old locations and move it
-  for link in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
-    echo $link
-    old=`eval "$(echo "echo \\$OLD_XDG_${link}_DIR")"`
-    new=`eval "$(echo "echo \\$XDG_${link}_DIR")"`
+  for d in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
+    old=`eval "$(echo "echo \\$OLD_XDG_${d}_DIR")"`
+    new=`eval "$(echo "echo \\$XDG_${d}_DIR")"`
     if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ]; then
       mv "$old"/* "$new"/
     elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ]; then

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -108,8 +108,6 @@ append_dir LOCPATH $RUNTIME/usr/lib/locale
 test -f ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs && . ${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs
 for link in DOCUMENTS DESKTOP DOWNLOAD MUSIC PICTURES VIDEOS PUBLICSHARE TEMPLATES; do
   eval $(echo "OLD_XDG_${link}_DIR")=`eval "$(echo "echo \\$XDG_${link}_DIR")"`
-  # Echo for debugging
-  echo OLD_XDG_${link}_DIR=`eval $(echo "echo \\$XDG_${link}_DIR")`
 done
 
 # Setup user-dirs.* or run xdg-user-dirs-update if needed
@@ -157,16 +155,9 @@ else
     old=`eval "$(echo "echo \\$OLD_XDG_${link}_DIR")"`
     new=`eval "$(echo "echo \\$XDG_${link}_DIR")"`
     if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ]; then
-      # Echo for debugging
-      echo "$old" is not "$new", migrating content
       mv "$old"/* "$new"/
     elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ]; then
-      # Echo for debugging
-      echo "$old" is not "$new", migrating content
       mv "$old"/* "$new"/
-    else
-      # Echo for debugging
-      echo "$old" is "$new", not migrating content
     fi
   done
 fi

--- a/common/init
+++ b/common/init
@@ -13,6 +13,17 @@ if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
   needs_update=false
 fi
 
+# Set $REALHOME to the users real home directory
+REALHOME=`getent passwd $UID | cut -d ':' -f 6`
+
+# If the user has modified their user-dirs settings, force an update
+if [[ -f $HOME/.config/user-dirs.dirs.md5sum && -f $HOME/.config/user-dirs.locale.md5sum ]]; then
+  if [[ "$(md5sum < $REALHOME/.config/user-dirs.dirs)" != "$(cat $HOME/.config/user-dirs.dirs.md5sum)" ||
+        "$(md5sum < $REALHOME/.config/user-dirs.locale)" != "$(cat $HOME/.config/user-dirs.locale.md5sum)" ]]; then
+    needs_update=true
+  fi
+fi
+
 if [ "$SNAP_ARCH" == "amd64" ]; then
   ARCH="x86_64-linux-gnu"
 elif [ "$SNAP_ARCH" == "armhf" ]; then

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -25,10 +25,4 @@ if [ $needs_update = true ]; then
     $RUNTIME/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0 > $GTK_IM_MODULE_FILE
   fi
 fi
-# create symbolic link to ibus socket path for ibus to look up its socket files
-# (see comments #3 and #6 on https://launchpad.net/bugs/1580463)
-IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
-mkdir -p $IBUS_CONFIG_PATH
-[ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
-ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
 

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -12,8 +12,6 @@ else
 fi
 
 # ibus and fcitx integration
-# with those definitions fcitx works unconfined out of the box, ibus requires
-# user config to be copied though, https://launchpad.net/bugs/1580463
 GTK_IM_MODULE_DIR=$XDG_CACHE_HOME/immodules
 export GTK_IM_MODULE_FILE=$GTK_IM_MODULE_DIR/immodules.cache
 if [ $needs_update = true ]; then
@@ -27,4 +25,10 @@ if [ $needs_update = true ]; then
     $RUNTIME/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0 > $GTK_IM_MODULE_FILE
   fi
 fi
+# create symbolic link to ibus socket path for ibus to look up its socket files
+# (see comments #3 and #6 on https://launchpad.net/bugs/1580463)
+IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
+mkdir -p $IBUS_CONFIG_PATH
+[ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
+ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -76,6 +76,8 @@ parts:
       - unity-gtk2-module
       - libappindicator1
       - locales-all
+      - ibus-gtk
+      - libibus-1.0-5
   gtk3:
     source: .
     source-subdir: gtk
@@ -175,6 +177,8 @@ parts:
       - locales-all
       - libappindicator1
       - xdg-user-dirs
+      - ibus-gtk
+      - libibus-1.0-5
   desktop-gtk3:
     source: .
     source-subdir: gtk
@@ -198,6 +202,8 @@ parts:
       - libappindicator3-1
       - locales-all
       - xdg-user-dirs
+      - ibus-gtk3
+      - libibus-1.0-5
   desktop-qt4:
     source: .
     source-subdir: qt

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,6 +99,8 @@ parts:
       - libappindicator3-1
       - locales-all
       - xdg-user-dirs
+      - ibus-gtk3
+      - libibus-1.0-5
   qt4:
     source: .
     source-subdir: qt


### PR DESCRIPTION
The desktop interface actually gives us access to the users $XDG_CONFIG_HOME/user-dirs.*, so we should link those into the snap's $XDG_CONFIG_HOME to get the proper user-dirs.