### PR TITLE
Fix FONTCONFIG_PATH to point to where we generate fonts.conf

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -209,7 +209,7 @@ IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 
 # Font Config and themes
 export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d
-export FONTCONFIG_FILE=$RUNTIME/etc/fonts/fonts.conf
+export FONTCONFIG_FILE=$XDG_CONFIG_HOME/fontconfig/fonts.conf
 
 function make_user_fontconfig {
   echo "<fontconfig>"
@@ -237,7 +237,7 @@ function make_user_fontconfig {
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
   mkdir -p $XDG_CONFIG_HOME/fontconfig
-  make_user_fontconfig > $XDG_CONFIG_HOME/fontconfig/fonts.conf
+  make_user_fontconfig > $FONTCONFIG_FILE
 
   # the themes symlink are needed for GTK 3.18 when the prefix isn't changed
   # GTK 3.20 looks into XDG_DATA_DIR which has connected themes.


### PR DESCRIPTION
Pointing fontconfig to the snapped fonts.conf file fails as the paths in the snapped file have not been edited to suit the snapped directory layout. This causes crashes in chromium/electron based apps for me.