### PR TITLE
[RFC] Improve wayland auto-detection and client support

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -161,6 +161,9 @@ else
   done
 fi
 
+# We should test if an X11 $DISPLAY variable is set first
+display_server="x11"
+
 # If detect wayland server socket, then set environment so applications prefer
 # wayland, and setup compat symlink (until we use user mounts. Remember,
 # XDG_RUNTIME_DIR is /run/user/<uid>/snap.$SNAP so look in the parent directory
@@ -175,12 +178,12 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     fi
     wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
     wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
-    if [ -S "$wayland_sockpath" ]; then
+    if [ -S "$wayland_snappath" ]; then
+      display_server="wayland"
+    elif [ -S "$wayland_sockpath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
-        export GDK_BACKEND="wayland"
-        export CLUTTER_BACKEND="wayland"
-        export QT_QPA_PLATFORM="wayland-egl"
+        display_server="wayland"
         # create the compat symlink for now
         if [ ! -e "$wayland_snappath" ]; then
             ln -s "$wayland_sockpath" "$wayland_snappath"

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -11,6 +11,15 @@ else
   export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-2.0
 fi
 
+if [ "$display_server" = "wayland" ]; then
+  if [ not "$USE_gtk3" = true ]; then
+    echo "Gtk2 does not support Wayland" >&2
+    exit 1
+  fi
+  export GDK_BACKEND="wayland"
+  export CLUTTER_BACKEND="wayland"
+fi
+
 # ibus and fcitx integration
 GTK_IM_MODULE_DIR=$XDG_CACHE_HOME/immodules
 export GTK_IM_MODULE_FILE=$GTK_IM_MODULE_DIR/immodules.cache

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -27,14 +27,23 @@ if [ "$USE_qt5" = true ]; then
   export QT_PRINTER_MODULE=qtubuntu-print
   [ "$WITH_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
-  # If a X11 $DISPLAY variable is set we should use it
-  export QT_QPA_PLATFORM=xcb
-  export QT_QPA_PLATFORMTHEME=appmenu-qt5
+
+  if [ "$display_server" = "x11" ]; then
+    export QT_QPA_PLATFORM="xcb"
+    export QT_QPA_PLATFORMTHEME="appmenu-qt5"
+  else
+    export QT_QPA_PLATFORM="wayland-egl"
+  fi
 else
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/qt4
   export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt4/plugins
   export QML_IMPORT_PATH=$SNAP/usr/lib/$ARCH/qt4/qml:$SNAP/lib/$ARCH:$QML_IMPORT_PATH
   PATH=$SNAP/usr/lib/$ARCH/qt4/bin:$PATH
+
+  if [ "$display_server" = "wayland" ]; then
+    echo "Qt4 does not support Wayland" >&2
+    exit 1
+  fi
 fi
 
 # Use GTK styling for running under the GNOME desktop


### PR DESCRIPTION
Have common desktop-exports detect wayland or x11, leaving toolkit specific launchers set the display server specific env vars correctly. Look for wayland socket in $XDG_RUNTIME_DIR itself.

And return error if trying to use wayland with an old toolkit that doesn't support it. I'm curious what you think of that.