### PR TITLE
common/desktop-exports: include EGL vendor dir on glvnd enabled systems

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -63,6 +63,10 @@ append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/libunity
 # Pulseaudio export
 append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/pulseaudio
 
+# EGL vendor files on glvnd enabled systems
+[ -d /var/lib/snapd/lib/glvnd/egl_vendor.d ] && \
+    append_dir __EGL_VENDOR_LIBRARY_DIRS /var/lib/snapd/lib/glvnd/egl_vendor.d
+
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
 export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0


### PR DESCRIPTION
Snapd can expose EGL vendor directory on glvnd enabled nvidia based systems .
Make sure to advertise the location through `__EGL_VENDOR_LIBRARY_DIRS` so that
glvnd runtime can properly locate vendor files.

Related snapd forum topic: https://forum.snapcraft.io/t/nvidia-gl-libs-access-broken-on-ubuntu-18-04/4440/31?u=mborzecki