### PR TITLE
desktop-exports: Improve command detection method

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -138,7 +138,7 @@ for d in ${XDG_SPECIAL_DIRS[@]}; do
 done
 
 # If needs XDG update and xdg-user-dirs-update exists in $PATH, run it
-if [ $needs_xdg_update = true ] && [ `which xdg-user-dirs-update` ]; then
+if [ $needs_xdg_update = true ] && command -v xdg-user-dirs-update >/dev/null; then
    xdg-user-dirs-update
 fi
     
@@ -255,7 +255,7 @@ fi
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/mime
   if [ ! -f $RUNTIME/usr/share/mime/mime.cache ]; then
-    if [ `which update-mime-database` ]; then
+    if command -v update-mime-database >/dev/null; then
       cp --preserve=timestamps -dR $RUNTIME/usr/share/mime $XDG_DATA_HOME
       update-mime-database $XDG_DATA_HOME/mime
     fi


### PR DESCRIPTION
Previously the script relies on the behavior of `test`(builtin) when 1 arguments is given(returns 0 when argument string not null, 1 elsewise), which is unnecessary and error-prone when the command path contains spaces.  This patch replaces them with straight-forward return value checking of `command`(also builtin).

Maybe-related-to: desktop-launch: line 199: [: too many arguments · Issue #114 · ubuntu/snapcraft-desktop-helpers <https://github.com/ubuntu/snapcraft-desktop-helpers/issues/114>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>