### PR TITLE
desktop-exports: ensure we have $HOME/.config dir

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -120,6 +120,7 @@ done
 needs_xdg_update=false
 needs_xdg_links=false
 if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
+   ! [ -d "$HOME/.config/" ] && mkdir -p $HOME/.config
    sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
    cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
    for f in user-dirs.dirs user-dirs.locale; do

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -120,7 +120,7 @@ done
 needs_xdg_update=false
 needs_xdg_links=false
 if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
-   ! [ -d "$HOME/.config/" ] && mkdir -p $HOME/.config
+   mkdir -p $HOME/.config -m 700
    sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
    cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
    for f in user-dirs.dirs user-dirs.locale; do


### PR DESCRIPTION
Create it if it doesn't exist, otherwise next operations will fail

I was just running a snap, while I noticed:

```
marco@tricky:/data/telegram-snap (master):✓ $ mailspring 
/snap/mailspring/216/bin/desktop-launch: line 177: /home/marco/snap/mailspring/common/.config/user-dirs.dirs: No such file or directory
cp: cannot create regular file '/home/marco/snap/mailspring/common/.config/': Not a directory
/snap/mailspring/216/bin/desktop-launch: line 180: /home/marco/snap/mailspring/common/.config/user-dirs.dirs.md5sum: No such file or directory
/snap/mailspring/216/bin/desktop-launch: line 180: /home/marco/snap/mailspring/common/.config/user-dirs.locale.md5sum: No such file or directory
```