### PR TITLE
Output some profiling information when $SNAP_DESKTOP_DEBUG is set

### DIFF
--- a/common/init
+++ b/common/init
@@ -2,6 +2,8 @@
 # Launcher init #
 #################
 
+START=$(date +%s.%N)
+
 # On Fedora $SNAP is under /var and there is some magic to map it to /snap.
 # # We need to handle that case and reset $SNAP
 SNAP=`echo $SNAP | sed -e "s|/var/lib/snapd||g"`

--- a/common/mark-and-exec
+++ b/common/mark-and-exec
@@ -4,4 +4,9 @@
 
 [ $needs_update = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > $SNAP_USER_DATA/.last_revision
 
+if [ -n "$SNAP_DESKTOP_DEBUG" ]; then
+  echo "desktop-launch elapsed time: " $(date +%s.%N --date="$START seconds ago") 
+  echo "Now running: exec $@"
+fi
+
 exec "$@"


### PR DESCRIPTION
Specifically, this outputs elapsed time for now, but we could introduce further debug output.