### PR TITLE
Move toolkit-specific decisions out of common

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -174,6 +174,7 @@ fi
 # https://forum.snapcraft.io/t/wayland-dconf-and-xdg-runtime-dir/186/10
 # Applications that don't support wayland natively may define DISABLE_WAYLAND
 # (to any non-empty value) to skip that logic entirely.
+wayland_available=false
 if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     wdisplay="wayland-0"
     if [ -n "$WAYLAND_DISPLAY" ]; then
@@ -184,9 +185,7 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     if [ -S "$wayland_sockpath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
-        export GDK_BACKEND="wayland"
-        export CLUTTER_BACKEND="wayland"
-        export QT_QPA_PLATFORM="wayland-egl"
+        wayland_available=true
         # create the compat symlink for now
         if [ ! -e "$wayland_snappath" ]; then
             ln -s "$wayland_sockpath" "$wayland_snappath"

--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -6,8 +6,15 @@
 . $SNAP/flavor-select
 
 if [ "$USE_gtk3" = true ]; then
+  if [ "$wayland_available" = true ]; then
+    export GDK_BACKEND="wayland"
+    export CLUTTER_BACKEND="wayland"
+    # Does not hurt to specify this as well, just in case
+    export QT_QPA_PLATFORM=wayland-egl
+  fi
   export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-3.0
 else
+  [ "$wayland_available" = true ] && echo "Warning: GTK2 does not support Wayland!"
   export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-2.0
 fi
 

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -27,10 +27,20 @@ if [ "$USE_qt5" = true ]; then
   export QT_PRINTER_MODULE=qtubuntu-print
   [ "$WITH_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
   PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
-  # If a X11 $DISPLAY variable is set we should use it
-  export QT_QPA_PLATFORM=xcb
-  export QT_QPA_PLATFORMTHEME=appmenu-qt5
+
+  if [ "$wayland_available" = true ]; then
+    export QT_QPA_PLATFORM=wayland-egl
+    # Does not hurt to specify these as well, just in case
+    export GDK_BACKEND="wayland"
+    export CLUTTER_BACKEND="wayland"
+  else
+    # Should check if a X11 $DISPLAY variable is set and accessible
+    export QT_QPA_PLATFORM=xcb
+    export QT_QPA_PLATFORMTHEME=appmenu-qt5
+  fi
+
 else
+  [ "$wayland_available" = true ] && echo "Warning: Qt4 does not support Wayland!"
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/qt4
   export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt4/plugins
   export QML_IMPORT_PATH=$SNAP/usr/lib/$ARCH/qt4/qml:$SNAP/lib/$ARCH:$QML_IMPORT_PATH


### PR DESCRIPTION
Fix Wayland support when using Qt5, and print a warning when trying to use Wayland with toolkits that do not support it