### PR TITLE
Revert change to FONTCONFIG_FILE, so we have a complete fontconfig configuration

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -243,6 +243,10 @@ function make_user_fontconfig {
 
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
+
+  # This fontconfig fragment is installed in a location that is
+  # included by the system fontconfig configuration: namely the
+  # etc/fonts/conf.d/50-user.conf file.
   mkdir -p $XDG_CONFIG_HOME/fontconfig
   make_user_fontconfig > $XDG_CONFIG_HOME/fontconfig/fonts.conf
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -215,7 +215,7 @@ IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 
 # Font Config and themes
 export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d
-export FONTCONFIG_FILE=$XDG_CONFIG_HOME/fontconfig/fonts.conf
+export FONTCONFIG_FILE=$RUNTIME/etc/fonts/fonts.conf
 
 function make_user_fontconfig {
   echo "<fontconfig>"
@@ -244,7 +244,7 @@ function make_user_fontconfig {
 if [ $needs_update = true ]; then
   rm -rf $XDG_DATA_HOME/{fontconfig,fonts,fonts-*,themes,.themes}
   mkdir -p $XDG_CONFIG_HOME/fontconfig
-  make_user_fontconfig > $FONTCONFIG_FILE
+  make_user_fontconfig > $XDG_CONFIG_HOME/fontconfig/fonts.conf
 
   # the themes symlink are needed for GTK 3.18 when the prefix isn't changed
   # GTK 3.20 looks into XDG_DATA_DIR which has connected themes.


### PR DESCRIPTION
This PR reverts #115, which was the cause of applications regenerating all fontconfig cache files on first run.

The `fonts.conf` generated by desktop-launch is not a complete fontconfig configuration, but instead intended to be included by the main `${RUNTIME}/etc/fonts/fonts.conf` file.  Among other things, main `fonts.conf` file adds `/var/cache/fontconfig` as a cache directory: without that, the confined app can not take advantage of the host system caches.

This PR should also bring back the all the font aliases that applications depend on for correct font selection.

The purpose of PR #115 from @gerboland was to fix some problem with some Electron apps on Ubuntu Core systems, so this will probably reintroduce whatever problem that was.  On balance I think reversion is the right choice for now, followed by tracking down the real root cause of those problems.