### PR TITLE
Set FONTCONFIG_PATH correctly to fix loading in-snap fonts

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -214,7 +214,7 @@ prepend_dir GI_TYPELIB_PATH $SNAP/usr/lib/gjs/girepository-1.0
 IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 
 # Font Config and themes
-export FONTCONFIG_PATH=$RUNTIME/etc/fonts/conf.d
+export FONTCONFIG_PATH=$RUNTIME/etc/fonts
 export FONTCONFIG_FILE=$RUNTIME/etc/fonts/fonts.conf
 
 function make_user_fontconfig {


### PR DESCRIPTION
I noticed my failing GUI snaps on Core were doing this:

    [pid 18922] access("/snap/gtk3-example/x1/etc/fonts/conf.d/conf.d", R_OK) = -1 ENOENT (No such file or directory)

which suggested the FONTCONFIG_PATH was incorrectly including "conf.d". This patch fixes my font loading issues, and doesn't break any desktop snap fonts I've tried.