### PR TITLE
List build-essential as one of the `build-packages` for gtk parts

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -160,6 +160,7 @@ parts:
     plugin: make
     make-parameters: ["FLAVOR=gtk2"]
     build-packages:
+      - build-essential
       - libgtk2.0-dev
     stage-packages:
       - libxkbcommon0  # XKB_CONFIG_ROOT
@@ -185,6 +186,7 @@ parts:
     plugin: make
     make-parameters: ["FLAVOR=gtk3"]
     build-packages:
+      - build-essential
       - libgtk-3-dev
     stage-packages:
       - libxkbcommon0  # XKB_CONFIG_ROOT
@@ -263,6 +265,7 @@ parts:
     plugin: make
     make-parameters: ["FLAVOR=gtk3"]
     build-packages:
+      - build-essential
       - libgtk-3-dev
     override-build: |
       snapcraftctl build


### PR DESCRIPTION
Avoid `make: gcc: Command not found` error when the including snap
doesn't require a GCC toolchain by itself.

Fixes #146.

Refer-to: gtk3 part doesn't install gcc · Issue #146 ·
ubuntu/snapcraft-desktop-helpers
<https://github.com/ubuntu/snapcraft-desktop-helpers/issues/146>
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>