### PR TITLE
Quote all DESTDIR expansions for paths contain spaces

### DIFF
--- a/glib-only/Makefile
+++ b/glib-only/Makefile
@@ -17,4 +17,4 @@ $(DEST_LAUNCHER):
 	@cat $(SRC_DIR)/mark-and-exec >> $(DEST_LAUNCHER)
 		
 install: $(DEST_LAUNCHER)
-	install -D -m755 $(DEST_LAUNCHER) $(DESTDIR)/bin/$(DEST_LAUNCHER)
+	install -D -m755 $(DEST_LAUNCHER) "$(DESTDIR)"/bin/$(DEST_LAUNCHER)

--- a/gtk/Makefile
+++ b/gtk/Makefile
@@ -25,6 +25,6 @@ $(DEST_LAUNCHER):
 	gcc -Wall -O2 -o $(BINDTEXTDOMAIN) -fPIC -shared $(SRC_DIR)/../src/bindtextdomain.c -ldl
 		
 install: $(DEST_LAUNCHER)
-	install -D -m755 $(DEST_LAUNCHER) $(DESTDIR)/bin/$(DEST_LAUNCHER)
-	install -D -m644 $(FLAVOR_FILE) $(DESTDIR)/
-	install -D -m644 $(BINDTEXTDOMAIN) $(DESTDIR)/lib/$(BINDTEXTDOMAIN)
+	install -D -m755 $(DEST_LAUNCHER) "$(DESTDIR)"/bin/$(DEST_LAUNCHER)
+	install -D -m644 $(FLAVOR_FILE) "$(DESTDIR)"/
+	install -D -m644 $(BINDTEXTDOMAIN) "$(DESTDIR)"/lib/$(BINDTEXTDOMAIN)

--- a/qt/Makefile
+++ b/qt/Makefile
@@ -40,10 +40,10 @@ desktop-launch:
 	@echo "USE_$(FLAVOR)=true" >> $(FLAVOR_FILE)
 		
 install: desktop-launch
-	install -D -m755 $(DEST_LAUNCHER) $(DESTDIR)/bin/$(DEST_LAUNCHER)
+	install -D -m755 $(DEST_LAUNCHER) "$(DESTDIR)"/bin/$(DEST_LAUNCHER)
 	install -D -m644 snappy-qt5.conf \
-		$(DESTDIR)/etc/xdg/qtchooser/snappy-qt5.conf
+		"$(DESTDIR)"/etc/xdg/qtchooser/snappy-qt5.conf
 	install -D -m644 snappy-qt4.conf \
-		$(DESTDIR)/etc/xdg/qtchooser/snappy-qt4.conf
-	install -D -m644 $(FLAVOR_FILE) $(DESTDIR)/
+		"$(DESTDIR)"/etc/xdg/qtchooser/snappy-qt4.conf
+	install -D -m644 $(FLAVOR_FILE) "$(DESTDIR)"/
 


### PR DESCRIPTION
Fixes #148.

Refer-to: Docker build breaks when snap repo path contains spaces ·
Issue #148 · ubuntu/snapcraft-desktop-helpers <https://github.com/ubuntu/snapcraft-desktop-helpers/issues/148
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>