### PR TITLE
List build-essential as one of the `build-packages` for qt parts (#141)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -212,6 +212,7 @@ parts:
     plugin: make
     make-parameters: ["FLAVOR=qt4"]
     build-packages:
+      - build-essential
       - libqt4-dev
       - dpkg-dev
     stage-packages:
@@ -235,6 +236,7 @@ parts:
     plugin: make
     make-parameters: ["FLAVOR=qt5"]
     build-packages:
+      - build-essential
       - qtbase5-dev
       - dpkg-dev
     stage-packages:


### PR DESCRIPTION
Avoid `make: gcc: Command not found` error when the including snap doesn't require a GCC toolchain by itself.