### PR TITLE
Stage Fcitx frontend

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -206,6 +206,7 @@ parts:
       - xdg-user-dirs
       - ibus-gtk3
       - libibus-1.0-5
+      - fcitx-frontend-gtk3
   desktop-qt4:
     source: .
     source-subdir: qt


### PR DESCRIPTION
This allows Fcitx input method framework to be used in Gtk3 snapped apps

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>