### PR TITLE
Link themes from data-dir when it's mounted

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -272,8 +272,13 @@ if [ $needs_update = true ]; then
 
   # the themes symlink are needed for GTK 3.18 when the prefix isn't changed
   # GTK 3.20 looks into XDG_DATA_DIR which has connected themes.
-  ln -sf $RUNTIME/usr/share/themes $XDG_DATA_HOME
-  ln -sfn $RUNTIME/usr/share/themes $SNAP_USER_DATA/.themes
+  if [ -d $SNAP/data-dir/themes ]; then
+    ln -sf $SNAP/data-dir/themes $XDG_DATA_HOME
+    ln -sfn $SNAP/data-dir/themes $SNAP_USER_DATA/.themes
+  else
+    ln -sf $RUNTIME/usr/share/themes $XDG_DATA_HOME
+    ln -sfn $RUNTIME/usr/share/themes $SNAP_USER_DATA/.themes
+  fi
 fi
 
 # Build mime.cache

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -180,6 +180,9 @@ parts:
       - xdg-user-dirs
       - ibus-gtk
       - libibus-1.0-5
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-gtk3:
     source: .
     source-subdir: gtk
@@ -206,6 +209,9 @@ parts:
       - xdg-user-dirs
       - ibus-gtk3
       - libibus-1.0-5
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-qt4:
     source: .
     source-subdir: qt
@@ -230,6 +236,9 @@ parts:
       - locales-all
       - sni-qt
       - xdg-user-dirs
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-qt5:
     source: .
     source-subdir: qt
@@ -253,6 +262,9 @@ parts:
       - try: [appmenu-qt5] # not available on core18
       - locales-all
       - xdg-user-dirs
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-glib-only:
     source: .
     source-subdir: glib-only
@@ -272,3 +284,4 @@ parts:
     override-build: |
       snapcraftctl build
       mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir


### PR DESCRIPTION
If the themes dir from gtk-common-themes is mounted, create links based on it rather than bundled themes.  This fixes snaps using parts other than desktop-gnome-platform that also use the content interfaces provided by gtk-common-themes