### PR TITLE
gtk, qt: use append_dir to modify GTK_PATH

### DIFF
--- a/gtk/launcher-specific
+++ b/gtk/launcher-specific
@@ -12,10 +12,10 @@ if [ "$USE_gtk3" = true ]; then
     # Does not hurt to specify this as well, just in case
     export QT_QPA_PLATFORM=wayland-egl
   fi
-  export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-3.0
+  append_dir GTK_PATH $RUNTIME/usr/lib/$ARCH/gtk-3.0
 else
   [ "$wayland_available" = true ] && echo "Warning: GTK2 does not support Wayland!"
-  export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-2.0
+  append_dir GTK_PATH $RUNTIME/usr/lib/$ARCH/gtk-2.0
 fi
 
 # ibus and fcitx integration

--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -21,12 +21,12 @@ export QTCOMPOSE=$RUNTIME/usr/share/X11/locale
 
 # Qt Libs, Modules and helpers
 if [ "$USE_qt5" = true ]; then
-  export QT_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/qt5/plugins
-  export QML2_IMPORT_PATH=$RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
+  prepend_dir QT_PLUGIN_PATH $RUNTIME/usr/lib/$ARCH/qt5/plugins
+  prepend_dir QML2_IMPORT_PATH $RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH/qt5/qml
   # Try to use qtubuntu-print plugin, if not found Qt will fallback to the first found (usually cups plugin)
   export QT_PRINTER_MODULE=qtubuntu-print
-  [ "$WITH_RUNTIME" = yes ] && QML2_IMPORT_PATH=$SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml:$QML2_IMPORT_PATH
-  PATH=$RUNTIME/usr/lib/$ARCH/qt5/bin:$PATH
+  [ "$WITH_RUNTIME" = yes ] && prepend_dir QML2_IMPORT_PATH $SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml
+  prepend_dir PATH $RUNTIME/usr/lib/$ARCH/qt5/bin
 
   if [ "$wayland_available" = true ]; then
     export QT_QPA_PLATFORM=wayland-egl
@@ -41,12 +41,12 @@ if [ "$USE_qt5" = true ]; then
 
 else
   [ "$wayland_available" = true ] && echo "Warning: Qt4 does not support Wayland!"
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/$ARCH/qt4
+  append_dir LD_LIBRARY_PATH $SNAP/usr/lib/$ARCH/qt4
   export QT_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/qt4/plugins
-  export QML_IMPORT_PATH=$SNAP/usr/lib/$ARCH/qt4/qml:$SNAP/lib/$ARCH:$QML_IMPORT_PATH
-  PATH=$SNAP/usr/lib/$ARCH/qt4/bin:$PATH
+  prepend_dir QML_IMPORT_PATH $SNAP/usr/lib/$ARCH/qt4/qml:$SNAP/lib/$ARCH
+  prepend_dir PATH $SNAP/usr/lib/$ARCH/qt4/bin
 fi
 
 # Use GTK styling for running under the GNOME desktop
-export GTK_PATH=$RUNTIME/usr/lib/$ARCH/gtk-2.0
+append_dir GTK_PATH $RUNTIME/usr/lib/$ARCH/gtk-2.0
 


### PR DESCRIPTION
When working on a demo of a snap using the gtk2-common-themes snap, I needed to set `GTK_PATH` to point at the engines provided by that package.  However, the desktop-launch script turns around and resets it on us.

This branch modifies the GTK and Qt scripts to use the `append_dir` helper defined in `common/desktop-exports` to update the variable instead.