### PR TITLE
Don't create data-dir

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -209,9 +209,6 @@ parts:
       - xdg-user-dirs
       - ibus-gtk3
       - libibus-1.0-5
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-qt4:
     source: .
     source-subdir: qt
@@ -236,9 +233,6 @@ parts:
       - locales-all
       - sni-qt
       - xdg-user-dirs
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-qt5:
     source: .
     source-subdir: qt
@@ -262,9 +256,6 @@ parts:
       - try: [appmenu-qt5] # not available on core18
       - locales-all
       - xdg-user-dirs
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir
   desktop-glib-only:
     source: .
     source-subdir: glib-only
@@ -284,4 +275,3 @@ parts:
     override-build: |
       snapcraftctl build
       mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/data-dir


### PR DESCRIPTION
Now that snapd has fixed the need to create data-dir, now it fails to mount if we create the dir in the snap.

https://github.com/snapcore/snapd/pull/5395