### PR TITLE
desktop-exports: Fixes and improvements for XDG dirs generations

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -197,9 +197,10 @@ else
     old="${XDG_SPECIAL_DIRS_INITIAL_PATHS[$i]}"
     new="${XDG_SPECIAL_DIRS_PATHS[$i]}"
     if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ]; then
-      mv "$old"/* "$new"/ 2>/dev/null
-    elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ]; then
-      mv "$old"/* "$new"/ 2>/dev/null
+      mv -vn "$old"/* "$new"/ 2>/dev/null
+    elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ] &&
+         (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then
+      mv -vn "$old"/* "$new"/ 2>/dev/null
     fi
   done
 fi

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -187,9 +187,10 @@ fi
 # Create links for user-dirs.dirs
 if [ $needs_xdg_links = true ]; then
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
-    b=$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$REALHOME")
-    if [ -e $REALHOME/$b ] && [ ! -e $HOME/$b ]; then
-      ln -s $REALHOME/$b $HOME/$b
+    b=$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")
+    if [ -e $REALHOME/$b ]; then
+      [ -d $HOME/$b ] && rmdir $HOME/$b 2> /dev/null
+      [ ! -e $HOME/$b ] && ln -s $REALHOME/$b $HOME/$b
     fi
   done
 else

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -169,18 +169,23 @@ else
   needs_xdg_links=true
 fi
 
+if [ $needs_xdg_reload = true ]; then
+  update_xdg_dirs_values
+  needs_xdg_reload=false
+fi
+
 # Check if we can actually read the contents of each xdg dir
 for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
   if ! can_open_file "${XDG_SPECIAL_DIRS_PATHS[$i]}"; then
     needs_xdg_update=true
+    needs_xdg_links=true
+    break
   fi
 done
 
 # If needs XDG update and xdg-user-dirs-update exists in $PATH, run it
 if [ $needs_xdg_update = true ] && command -v xdg-user-dirs-update >/dev/null; then
   xdg-user-dirs-update
-  update_xdg_dirs_values
-elif [ $needs_xdg_reload = true ]; then
   update_xdg_dirs_values
 fi
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -156,12 +156,13 @@ if [ "$HOME" != "$SNAP_USER_DATA" ] && ! is_subpath "$XDG_CONFIG_HOME" "$HOME"; 
 fi
 
 if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
-  if [ $needs_xdg_reload = true ]; then
+  if [ $needs_update = true ] || [ $needs_xdg_reload = true ]; then
     sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $XDG_CONFIG_HOME/user-dirs.dirs
     cp -a $REALHOME/.config/user-dirs.locale $XDG_CONFIG_HOME
     for f in user-dirs.dirs user-dirs.locale; do
       md5sum < $REALHOME/.config/$f > $XDG_CONFIG_HOME/$f.md5sum
     done
+    needs_xdg_reload=true
   fi
 else
   needs_xdg_update=true
@@ -418,4 +419,3 @@ IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
 mkdir -p $IBUS_CONFIG_PATH
 [ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
 ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
-

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -126,10 +126,6 @@ if [[ -d $SNAP_USER_DATA/.cache && ! -e $XDG_CACHE_HOME ]]; then
 fi
 mkdir -p $XDG_CACHE_HOME
 
-# Set config folder to local path
-export XDG_CONFIG_HOME=$SNAP_USER_DATA/.config
-mkdir -p $XDG_CONFIG_HOME
-
 # Create $XDG_RUNTIME_DIR if not exists (to be removed when LP: #1656340 is fixed)
 [ -n "$XDG_RUNTIME_DIR" ] && mkdir -p $XDG_RUNTIME_DIR -m 700
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -409,13 +409,12 @@ fi
 
 # GTK theme and behavior modifier
 # Those can impact the theme engine used by Qt as well
-gtk_configs=(.config/gtk-3.0/settings.ini .config/gtk-3.0/bookmarks .config/gtk-2.0/gtkfilechooser.ini)
+gtk_configs=(gtk-3.0/settings.ini gtk-3.0/bookmarks gtk-2.0/gtkfilechooser.ini)
 for f in ${gtk_configs[@]}; do
-  dest="$SNAP_USER_DATA/$f"
-  if [ ! -L "$dest" ]
-  then
+  dest="$XDG_CONFIG_HOME/$f"
+  if [ ! -L "$dest" ]; then
     mkdir -p `dirname $dest`
-    ln -s $REALHOME/$f $dest
+    ln -s $REALHOME/.config/$f $dest
   fi
 done
 

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -48,6 +48,12 @@ function update_xdg_dirs_values() {
   done
 }
 
+function is_subpath() {
+  dir=$(realpath $1)
+  parent=$(realpath $2)
+  [ "${dir##$parent/}" != "$dir" ] && return 0 || return 1
+}
+
 WITH_RUNTIME=no
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
@@ -137,16 +143,29 @@ update_xdg_dirs_values
 
 # Setup user-dirs.* or run xdg-user-dirs-update if needed
 needs_xdg_update=false
+needs_xdg_reload=false
 needs_xdg_links=false
+
+if [ "$HOME" != "$SNAP_USER_DATA" ] && ! is_subpath "$XDG_CONFIG_HOME" "$HOME"; then
+  for f in user-dirs.dirs user-dirs.locale; do
+    if [ -f "$HOME/.config/$f" ]; then
+      mv "$HOME/.config/$f" "$XDG_CONFIG_HOME"
+      needs_xdg_reload=true
+    fi
+  done
+fi
+
 if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
-   sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $XDG_CONFIG_HOME/user-dirs.dirs
-   cp -a $REALHOME/.config/user-dirs.locale $XDG_CONFIG_HOME
-   for f in user-dirs.dirs user-dirs.locale; do
-     md5sum < $REALHOME/.config/$f > $XDG_CONFIG_HOME/$f.md5sum
-   done
+  if [ $needs_xdg_reload = true ]; then
+    sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $XDG_CONFIG_HOME/user-dirs.dirs
+    cp -a $REALHOME/.config/user-dirs.locale $XDG_CONFIG_HOME
+    for f in user-dirs.dirs user-dirs.locale; do
+      md5sum < $REALHOME/.config/$f > $XDG_CONFIG_HOME/$f.md5sum
+    done
+  fi
 else
-   needs_xdg_update=true
-   needs_xdg_links=true
+  needs_xdg_update=true
+  needs_xdg_links=true
 fi
 
 # Check if we can actually read the contents of each xdg dir
@@ -158,8 +177,10 @@ done
 
 # If needs XDG update and xdg-user-dirs-update exists in $PATH, run it
 if [ $needs_xdg_update = true ] && command -v xdg-user-dirs-update >/dev/null; then
-   xdg-user-dirs-update
-   update_xdg_dirs_values
+  xdg-user-dirs-update
+  update_xdg_dirs_values
+elif [ $needs_xdg_reload = true ]; then
+  update_xdg_dirs_values
 fi
 
 # Create links for user-dirs.dirs

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -139,11 +139,10 @@ update_xdg_dirs_values
 needs_xdg_update=false
 needs_xdg_links=false
 if can_open_file "$REALHOME/.config/user-dirs.dirs" && can_open_file "$REALHOME/.config/user-dirs.locale"; then
-   mkdir -p $HOME/.config -m 700
-   sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $HOME/.config/user-dirs.dirs
-   cp -a $REALHOME/.config/user-dirs.locale $HOME/.config/
+   sed /^#/!s#\$HOME#${REALHOME}#g $REALHOME/.config/user-dirs.dirs > $XDG_CONFIG_HOME/user-dirs.dirs
+   cp -a $REALHOME/.config/user-dirs.locale $XDG_CONFIG_HOME
    for f in user-dirs.dirs user-dirs.locale; do
-     md5sum < $REALHOME/.config/$f > $HOME/.config/$f.md5sum
+     md5sum < $REALHOME/.config/$f > $XDG_CONFIG_HOME/$f.md5sum
    done
 else
    needs_xdg_update=true

--- a/common/init
+++ b/common/init
@@ -28,6 +28,8 @@ if [[ -f $XDG_CONFIG_HOME/user-dirs.dirs.md5sum && -f $XDG_CONFIG_HOME/user-dirs
         "$(md5sum < $REALHOME/.config/user-dirs.locale)" != "$(cat $XDG_CONFIG_HOME/user-dirs.locale.md5sum)" ]]; then
     needs_update=true
   fi
+else
+  needs_update=true
 fi
 
 if [ "$SNAP_ARCH" == "amd64" ]; then

--- a/common/init
+++ b/common/init
@@ -18,6 +18,10 @@ fi
 # Set $REALHOME to the users real home directory
 REALHOME=`getent passwd $UID | cut -d ':' -f 6`
 
+# Set config folder to local path
+export XDG_CONFIG_HOME=$SNAP_USER_DATA/.config
+mkdir -p $XDG_CONFIG_HOME -m 700
+
 # If the user has modified their user-dirs settings, force an update
 if [[ -f $HOME/.config/user-dirs.dirs.md5sum && -f $HOME/.config/user-dirs.locale.md5sum ]]; then
   if [[ "$(md5sum < $REALHOME/.config/user-dirs.dirs)" != "$(cat $HOME/.config/user-dirs.dirs.md5sum)" ||

--- a/common/init
+++ b/common/init
@@ -23,9 +23,9 @@ export XDG_CONFIG_HOME=$SNAP_USER_DATA/.config
 mkdir -p $XDG_CONFIG_HOME -m 700
 
 # If the user has modified their user-dirs settings, force an update
-if [[ -f $HOME/.config/user-dirs.dirs.md5sum && -f $HOME/.config/user-dirs.locale.md5sum ]]; then
-  if [[ "$(md5sum < $REALHOME/.config/user-dirs.dirs)" != "$(cat $HOME/.config/user-dirs.dirs.md5sum)" ||
-        "$(md5sum < $REALHOME/.config/user-dirs.locale)" != "$(cat $HOME/.config/user-dirs.locale.md5sum)" ]]; then
+if [[ -f $XDG_CONFIG_HOME/user-dirs.dirs.md5sum && -f $XDG_CONFIG_HOME/user-dirs.locale.md5sum ]]; then
+  if [[ "$(md5sum < $REALHOME/.config/user-dirs.dirs)" != "$(cat $XDG_CONFIG_HOME/user-dirs.dirs.md5sum)" ||
+        "$(md5sum < $REALHOME/.config/user-dirs.locale)" != "$(cat $XDG_CONFIG_HOME/user-dirs.locale.md5sum)" ]]; then
     needs_update=true
   fi
 fi


### PR DESCRIPTION
Various fixes on `user-dirs`, see each commit description for more clarity.

However, the main issue addressed here is making sure that `user-dirs.*`are inside `$XDG_CONFIG_HOME` and not in `$HOME/.config` as those two paths might not match when the snap doesn't have `HOME=$SNAP_USER_DATA` (quite common when using `$SNAP_USER_COMMON` as `HOME`) as in that case the file is created in both locations and the one inside `XDG_CONFIG_HOME` (with not-fixed values) takes the priority.

Also improved the cases for snaps with desktop interface but without home readability (so that now linking to paths on real home happens again), and improved dirs and files migrations and dirs definitions updates.