### PR TITLE
Make nimf runtime directory available inside the snap-specific $XDG_RUNTIME_DIR

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -424,3 +424,13 @@ IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
 mkdir -p $IBUS_CONFIG_PATH
 [ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
 ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
+
+# Make nimf runtime directory available inside the snap-specific
+# $XDG_RUNTIME_DIR
+if [ -n "$XDG_RUNTIME_DIR" ]; then
+    real_nimf_runtime_dir="$XDG_RUNTIME_DIR/../nimf"
+    snap_nimf_runtime_dir="$XDG_RUNTIME_DIR/nimf"
+    if [ -d "$real_nimf_runtime_dir" ]; then
+        ln -sf "$real_nimf_runtime_dir" "$snap_nimf_runtime_dir"
+    fi
+fi


### PR DESCRIPTION
Hello.
Nimf is an input method framework which has a module-based client-server architecture in which an application acts as a client and communicates synchronously with the Nimf server via a Unix socket.
For more information, please visit https://gitlab.com/nimf-i18n/nimf.

Nimf uses a `lock.pid` file for single-instance daemon, a `socket` file for security reasons.
These files are located in the `$XDG_RUNTIME_DIR/nimf` directory.
```
/run/user/<uid>/nimf/lock.pid
/run/user/<uid>/nimf/socket
```
This patch creates a symbolic link to `/run/user/<uid>/nimf` with the name `/run/user/<uid>/snap.$SNAP`.