### PR TITLE
Tell libva where to find the drivers.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -80,9 +80,10 @@ prepend_dir XCURSOR_PATH $SNAP/data-dir/icons
 append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa
 append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/mesa-egl
 
-# Tell libGL where to find the drivers
+# Tell libGL and libva where to find the drivers
 export LIBGL_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
 append_dir LD_LIBRARY_PATH $LIBGL_DRIVERS_PATH
+export LIBVA_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH


### PR DESCRIPTION
Note that this usually requires additional stage packages containing the drivers (i965-va-driver-shaders / mesa-va-drivers).