### PR TITLE
Fix ppc64el arch compatibility

### DIFF
--- a/common/init
+++ b/common/init
@@ -38,6 +38,8 @@ elif [ "$SNAP_ARCH" == "armhf" ]; then
   ARCH="arm-linux-gnueabihf"
 elif [ "$SNAP_ARCH" == "arm64" ]; then
   ARCH="aarch64-linux-gnu"
+elif [ "$SNAP_ARCH" == "ppc64el" ]; then
+  ARCH="powerpc64le-linux-gnu"
 else
   ARCH="$SNAP_ARCH-linux-gnu"
 fi


### PR DESCRIPTION
ppc64el arch has a special debian multiarch name and requires special casing, check out https://wiki.debian.org/Multiarch/Tuples for more info

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>