### PR TITLE
[qt] fix prepend_dir usage

### DIFF
--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -22,10 +22,14 @@ export QTCOMPOSE=$RUNTIME/usr/share/X11/locale
 # Qt Libs, Modules and helpers
 if [ "$USE_qt5" = true ]; then
   prepend_dir QT_PLUGIN_PATH $RUNTIME/usr/lib/$ARCH/qt5/plugins
-  prepend_dir QML2_IMPORT_PATH $RUNTIME/lib/$ARCH:$RUNTIME/usr/lib/$ARCH/qt5/qml
+  prepend_dir QML2_IMPORT_PATH $RUNTIME/usr/lib/$ARCH/qt5/qml
+  prepend_dir QML2_IMPORT_PATH $RUNTIME/lib/$ARCH
   # Try to use qtubuntu-print plugin, if not found Qt will fallback to the first found (usually cups plugin)
   export QT_PRINTER_MODULE=qtubuntu-print
-  [ "$WITH_RUNTIME" = yes ] && prepend_dir QML2_IMPORT_PATH $SNAP/lib/$ARCH:$SNAP/usr/lib/$ARCH/qt5/qml
+  if [ "$WITH_RUNTIME" = yes ]; then
+    prepend_dir QML2_IMPORT_PATH $SNAP/usr/lib/$ARCH/qt5/qml
+    prepend_dir QML2_IMPORT_PATH $SNAP/lib/$ARCH
+  fi
   prepend_dir PATH $RUNTIME/usr/lib/$ARCH/qt5/bin
 
   if [ "$wayland_available" = true ]; then


### PR DESCRIPTION
It doesn't allow colons, as it's checking for the directory to be one.