### PR TITLE
Make the launcher print the actual gnome runtime snap the user is required to install and connect

### DIFF
--- a/gtk/runtime-exports
+++ b/gtk/runtime-exports
@@ -5,14 +5,25 @@
 if [ -d $SNAP/gnome-platform ]; then
   RUNTIME=$SNAP/gnome-platform
   if [ ! -d $RUNTIME/usr ]; then
-    echo "You need to connect this snap to the gnome platform snap."
-    echo ""
-    echo "You can do this with those commands:"
-    echo "snap install gnome-3-26-1604"
-    echo "snap connect $SNAP_NAME:gnome-3-26-1604 gnome-3-26-1604"
-    echo ""
-    echo "(the '3-26-1604' number defines the platform version and might change)"
-    exit 1
+    platform_snap_name="$(
+        grep \
+            --extended-regexp \
+            'default-provider: *gnome-[[:digit:]]+-[[:digit:]]+-[[:digit:]]+' \
+            $SNAP/meta/snap.yaml \
+            | cut --delimiter=: --fields=2 \
+            | sed 's/^ *//' \
+            || true
+    )"
+
+    if test -n "${platform_snap_name}"; then
+        echo "You need to connect this snap to the gnome platform snap."
+        echo ""
+        echo "You can do this with those commands:"
+        echo "snap install ${platform_snap_name}"
+        echo "snap connect $SNAP_NAME:${platform_snap_name} ${platform_snap_name}"
+        echo ""
+        exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
The patch parses the actual providing snap name from $SNAP/meta/snap.yaml.

```
$ my-awesome-app 
You need to connect this snap to the gnome platform snap.

You can do this with those commands:
snap install gnome-3-28-1804
snap connect my-awesome-app:gnome-3-28-1804 gnome-3-28-1804
```

Fixes #178.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>