### PR TITLE
Only set QT_QPA_PLATFORMTHEME to appmenu-qt5 if it is not set by other value (or unset)

### DIFF
--- a/qt/launcher-specific
+++ b/qt/launcher-specific
@@ -40,7 +40,9 @@ if [ "$USE_qt5" = true ]; then
   else
     # Should check if a X11 $DISPLAY variable is set and accessible
     export QT_QPA_PLATFORM=xcb
-    export QT_QPA_PLATFORMTHEME=appmenu-qt5
+    if ! [ -v QT_QPA_PLATFORMTHEME ] || [ -z "${QT_QPA_PLATFORMTHEME}" ]; then
+      export QT_QPA_PLATFORMTHEME=appmenu-qt5
+    fi
   fi
 
 else


### PR DESCRIPTION
This allows gtk-common-themes integration, which requires QT_QPA_PLATFORMTHEME=gtk

Fixes #180 

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>