### PR TITLE
bindtextdomain: Support locale files under share/locale

### DIFF
--- a/src/bindtextdomain.c
+++ b/src/bindtextdomain.c
@@ -43,6 +43,7 @@ char *bindtextdomain(const char *domainname, const char *dirname)
                 goto orig;
 
         char * paths[] = {
+                "share/locale",
                 "gnome-platform/usr/share/locale",
                 "usr/share/locale",
                 "usr/share/locale-langpack",


### PR DESCRIPTION
This is the folder snapcraft will build into by default, and should be searched first.

Tested on a simple built-from-source zenity dialog, the I18N now works.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>