### PR TITLE
gnome-platform: Drop unnecessary build-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -269,8 +269,7 @@ parts:
     plugin: make
     make-parameters: ["FLAVOR=gtk3"]
     build-packages:
-      - build-essential
-      - libgtk-3-dev
+      - gcc
     override-build: |
       snapcraftctl build
       mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform


### PR DESCRIPTION
Only gcc package is required to build the bindtextdomain preload
library, the rest are redundant and make Snapcraft install a lot of
useless packages.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>