### PR TITLE
common/desktop-exports: include EGL vendor dir for Mesa

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -102,6 +102,10 @@ append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/pulseaudio
 [ -d /var/lib/snapd/lib/glvnd/egl_vendor.d ] && \
     append_dir __EGL_VENDOR_LIBRARY_DIRS /var/lib/snapd/lib/glvnd/egl_vendor.d
 
+# EGL vendor files
+append_dir __EGL_VENDOR_LIBRARY_DIRS $RUNTIME/etc/glvnd/egl_vendor.d
+append_dir __EGL_VENDOR_LIBRARY_DIRS $RUNTIME/usr/share/glvnd/egl_vendor.d
+
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0
 export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0


### PR DESCRIPTION
This allows libglvnd to find Mesa's EGL implementation and fixes things that rely on EGL under Wayland like SDL2 and Qt 5.

Fixes #172 
Also reported downstream: https://github.com/maxiberta/moonlight-snap/issues/7