### PR TITLE
snapcraft.yaml: add audio-playback for audio

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,8 +24,10 @@ description: |
        - for graphical application:
          plugs: [x11 (or unity7 for appmenu integration)]. Think about adding
          opengl if you need hw acceleration.
-       - if your application needs access to sound:
-         plugs: [pulseaudio]
+       - for sound playback:
+         plugs: [audio-playback, pulseaudio]
+       - for sound playback and recording:
+         plugs: [audio-playback, audio-record, pulseaudio]
        - accessing to user's home directory:
          plugs: [home]
        - read/write to gsettings:


### PR DESCRIPTION
The pulseaudio interface is being deprecated in favor of audio-playback.
While the pulseaudio is still going to be available for a while, it will
stop being auto-connected for new snaps. Instead, developers should
plugs 'audio-playback' or both 'audio-playback' and 'audio-record' if
need to record audio. These new interfaces are available in snapd 2.41
and will be maintained for other media services, like pipewire.