### PR TITLE
snapcraft.yaml: add audio-playback for audio

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,8 +30,10 @@ description: |
                 for details
        - if your application needs hw acceleration:
          plugs: [opengl]
-       - if your application needs access to sound:
-         plugs: [pulseaudio]
+       - for sound playback:
+         plugs: [audio-playback, pulseaudio]
+       - for sound playback and recording:
+         plugs: [audio-playback, audio-record, pulseaudio]
        - accessing to user's home directory:
          plugs: [home]
        - read/write to gsettings:


### PR DESCRIPTION
The pulseaudio interface is being deprecated in favor of audio-playback.
While the pulseaudio interface is still going to be available for a
while, it will stop being auto-connected for new snaps. Instead,
developers should plugs 'audio-playback' or both 'audio-playback' and
'audio-record' if the snap needs to record audio. These new interfaces
are available in snapd 2.41 and will be maintained for other media
services, like pipewire.