### PR TITLE
demo: qt5: use desktop plug

### DIFF
--- a/demos/qt5/snapcraft.yaml
+++ b/demos/qt5/snapcraft.yaml
@@ -8,7 +8,7 @@ confinement: strict
 apps:
   qt5-application:
     command: desktop-launch application
-    plugs: [unity7, home]
+    plugs: [desktop, home]
 
 parts:
   application:


### PR DESCRIPTION
Instead of the unity7 desktop plug use the newer plug "desktop"

I'm not sure if `desktop` or `desktop-legacy` is the right plug for the demo-example