### PR TITLE
snapcraft.yaml: remove pulseaudio from template

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -37,9 +37,9 @@ description: |
        - if your application needs hw acceleration:
          plugs: [opengl]
        - for sound playback:
-         plugs: [audio-playback, pulseaudio]
+         plugs: [audio-playback]
        - for sound playback and recording:
-         plugs: [audio-playback, audio-record, pulseaudio]
+         plugs: [audio-playback, audio-record]
        - accessing to user's home directory:
          plugs: [home]
        - read/write to gsettings:


### PR DESCRIPTION
8565db1e8be77e03e3dc483a42f9adde8654234d added audio-playback to the
snapcraft template. Now that audio-playback has been available in
several snapd releases and snapd 2.43 and later only manually connects
pulseaudio, removed pulseaudio from the template, leaving
audio-playback.