### PR TITLE
Regenerate the GDK pixbuf loaders cache file if for whatever reason it isn't there (LP: #1863801).

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -386,7 +386,7 @@ append_dir LD_LIBRARY_PATH $SNAP/testability/$ARCH/mesa
 # Gdk-pixbuf loaders
 export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
 export GDK_PIXBUF_MODULEDIR=$RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders
-if [ $needs_update = true ]; then
+if [ $needs_update = true ] || [ ! -f $GDK_PIXBUF_MODULE_FILE ]; then
   rm -f $GDK_PIXBUF_MODULE_FILE
   if [ -f $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
     async_exec $RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE


### PR DESCRIPTION
The absence of the cache file (after manual deletion) was causing the chromium snap to crash when opening a GTK file dialog.