### PR TITLE
Prepend GL paths rather than appending

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -86,12 +86,6 @@ export LIBGL_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
 append_dir LD_LIBRARY_PATH $LIBGL_DRIVERS_PATH
 export LIBVA_DRIVERS_PATH=$RUNTIME/usr/lib/$ARCH/dri
 
-# Workaround in snapd for proprietary nVidia drivers mounts the drivers in
-# /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
-# Without that OpenGL using apps do not work with the nVidia drivers.
-# Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
-append_dir LD_LIBRARY_PATH /var/lib/snapd/lib/gl
-
 # Unity7 export (workaround for https://launchpad.net/bugs/1638405)
 append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/libunity
 
@@ -100,7 +94,7 @@ append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/pulseaudio
 
 # EGL vendor files on glvnd enabled systems
 [ -d /var/lib/snapd/lib/glvnd/egl_vendor.d ] && \
-    append_dir __EGL_VENDOR_LIBRARY_DIRS /var/lib/snapd/lib/glvnd/egl_vendor.d
+    prepend_dir __EGL_VENDOR_LIBRARY_DIRS /var/lib/snapd/lib/glvnd/egl_vendor.d
 
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH=$SNAP/usr/lib/$ARCH/gstreamer-1.0


### PR DESCRIPTION
The problem with `__EGL_VENDOR_LIBRARY_DIRS` is that the first one that has _any_ configuration (e.g. [`50_mesa.json`](https://packages.ubuntu.com/search?searchon=contents&keywords=50_mesa.json&mode=exactfilename&suite=focal&arch=any)) will be picked up, even if further dirs have higher priority ones (e.g. [`10_nvidia.json`](https://packages.ubuntu.com/search?searchon=contents&keywords=10_nvidia.json&mode=exactfilename&suite=focal&arch=any).

`snapd` only puts stuff in `/var/lib/snapd/lib/gl{,vnd}` on systems with Nvidia, so snaps that use GL ship the Mesa stack "as a fallback". But it's the system one that should be picked up first.

More context:
https://github.com/NVIDIA/libglvnd/blob/master/src/EGL/icd_enumeration.md