### PR TITLE
Fix Documents, Pictures, Music etc are symlinks in

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -210,7 +210,7 @@ else
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS[@]}; i++)); do
     old="${XDG_SPECIAL_DIRS_INITIAL_PATHS[$i]}"
     new="${XDG_SPECIAL_DIRS_PATHS[$i]}"
-    if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ] &&
+    if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old" 2>/dev/null` != "$new" ] &&
          (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then
       mv -vn "$old"/* "$new"/ 2>/dev/null
     elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ] &&

--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -210,7 +210,8 @@ else
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS[@]}; i++)); do
     old="${XDG_SPECIAL_DIRS_INITIAL_PATHS[$i]}"
     new="${XDG_SPECIAL_DIRS_PATHS[$i]}"
-    if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ]; then
+    if [ -L "$old" ] && [ -d "$new" ] && [ `readlink "$old"` != "$new" ] &&
+         (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then
       mv -vn "$old"/* "$new"/ 2>/dev/null
     elif [ -d "$old" ] && [ -d "$new" ] && [ "$old" != "$new" ] &&
          (is_subpath "$old" "$SNAP_USER_DATA" || is_subpath "$old" "$SNAP_USER_COMMON"); then


### PR DESCRIPTION
When a user has one or several `XDG_SPECIAL_DIRS` folders symlinked in their real home folder to elsewhere in their real home folder `common/desktop-exports` will attempt to mv those folders to themselves.

* guard `mv` calls with test for `is_subpath` to ensure that we're only moving symlinks we created.

While this is not a fatal error here, the electron-builder copies are using `bash -e` so they fail hard. I will forward these changes to electron-builder once reviewed here... (currently symlinks for Documents etc, combined with the electron-builder default of plugging `home`, cause electron-builder-built snaps to refuse to launch because the `mv` calls break the execution due to `bash -e`.)

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>