### PR TITLE
suppress realpath noise on headless systems

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -199,8 +199,8 @@ fi
 # Create links for user-dirs.dirs
 if [ $needs_xdg_links = true ]; then
   for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
-    b=$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME")
-    if [[ "$b" != "." && -e $REALHOME/$b ]]; then
+    b="$(realpath "${XDG_SPECIAL_DIRS_PATHS[$i]}" --relative-to="$HOME" 2>/dev/null)"
+    if [[ -n "$b" && "$b" != "." && -e $REALHOME/$b ]]; then
       [ -d $HOME/$b ] && rmdir $HOME/$b 2> /dev/null
       [ ! -e $HOME/$b ] && ln -s $REALHOME/$b $HOME/$b
     fi


### PR DESCRIPTION
When on systems where a desktop session has never run,
desktop-launch will create noise complaining that paths cannot be found.
Simply redirect the error messages to /dev/null.

E.G, running over SSH in Multipass, using snaps in a CLI environment.

Additionally, prevent behaviour where rmdir $HOME would be called
by ensuring the variable is not empty.
This is unlikely to have caused problems as rmdir would not delete dirs
that have content, but it's better to not rely on semantics here.

-------------------------
I originally sent this as a patch to the extensions first https://github.com/snapcore/snapcraft/pull/3446 but it seems to not actually occur in the extensions themselves. See the output below showing the problem, tested on a clean Multipass instance.

```
ubuntu@main-panther:~/squashfs-root$ sudo snap install root-framework
root-framework v6-22-06 from James Carroll installed
ubuntu@main-panther:~/squashfs-root$ root
realpath: '': No such file or directory
realpath: '': No such file or directory
realpath: '': No such file or directory
realpath: '': No such file or directory
realpath: '': No such file or directory
realpath: '': No such file or directory
realpath: '': No such file or directory
realpath: '': No such file or directory
   ------------------------------------------------------------------
  | Welcome to ROOT 6.22/06                        https://root.cern |
  | (c) 1995-2020, The ROOT Team; conception: R. Brun, F. Rademakers |
  | Built for linuxx8664gcc on Feb 23 2021, 13:06:00                 |
  | From tags/v6-22-06@v6-22-06                                      |
  | Try '.help', '.demo', '.license', '.credits', '.quit'/'.q'       |
   ------------------------------------------------------------------

root [0] .q
ubuntu@main-panther:~/squashfs-root$
```
