### PR TITLE
Support fcitx5 on gtk3 and qt5 applications.

### DIFF
--- a/demos/qt5/snapcraft.yaml
+++ b/demos/qt5/snapcraft.yaml
@@ -54,6 +54,7 @@ parts:
       - locales-all
       - xdg-user-dirs
       - fcitx-frontend-qt5
+      - fcitx5-frontend-qt5
 
   qt5-gtk-platform:
     plugin: nil

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -215,6 +215,7 @@ parts:
       - ibus-gtk3
       - libibus-1.0-5
       - fcitx-frontend-gtk3
+      - fcitx5-frontend-gtk3
   desktop-qt4:
     source: .
     source-subdir: qt
@@ -263,6 +264,7 @@ parts:
       - locales-all
       - xdg-user-dirs
       - fcitx-frontend-qt5
+      - fcitx5-frontend-qt5
   desktop-glib-only:
     source: .
     source-subdir: glib-only


### PR DESCRIPTION
Recently, I noticed that fcitx5 does not work on different snap applications (e.g., Firefox, Slack, VsCode). Inspired by the PR [ubuntu#156](https://github.com/ubuntu/snapcraft-desktop-helpers/pull/156), I have added fcitx5 frontend packages to snap base to fix the issue.

cc @brlin-tw 
